### PR TITLE
feat: add wiki page update, delete, and get-by-slug tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- version list -->
 
+## v1.2.2 (2026-03-15)
+
+### Bug Fixes
+
+- **server**: Handle invalid JSON gracefully in _parse_mcp_kwargs
+  ([`355e6a8`](https://github.com/TETRA-2023/pytaiga-mcp/commit/355e6a8c8da95c209fc72d5d3e214c929ec6fb05))
+
+- **server**: Set default session on login and use correct slug lookup
+  ([`2148586`](https://github.com/TETRA-2023/pytaiga-mcp/commit/2148586bdf60fa93b5ba9342df41d36a42a8c732))
+
+### Documentation
+
+- Update README for Python 3.12, GHCR image, pre-commit hooks
+  ([`d28ffc2`](https://github.com/TETRA-2023/pytaiga-mcp/commit/d28ffc2db91e2f4384690025e75370a070382327))
+
+### Testing
+
+- Add filters key path coverage for _parse_mcp_kwargs
+  ([`30681e5`](https://github.com/TETRA-2023/pytaiga-mcp/commit/30681e5b0c15c6a8badc95f3619a4df3acb083dc))
+
+- Remove duplicate get_project_by_slug test
+  ([`662438c`](https://github.com/TETRA-2023/pytaiga-mcp/commit/662438ce8493eaeded0c7e87d7b122df0268c394))
+
+
 ## v1.2.1 (2026-03-15)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.2.3 (2026-03-16)
+
+### Bug Fixes
+
+- Disable pagination on all list calls via x-disable-pagination header
+  ([`ce35ae4`](https://github.com/TETRA-2023/pytaiga-mcp/commit/ce35ae46fc228633552211c00a6e392d405fa8c1))
+
+
 ## v1.2.2 (2026-03-15)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.3.0 (2026-03-24)
+
+### Features
+
+- Add SSE and streamable-http transport support
+  ([`ede5586`](https://github.com/TETRA-2023/pytaiga-mcp/commit/ede5586c526b3cfde73e1d8f7c821a6d37b25434))
+
+
 ## v1.2.3 (2026-03-16)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ The bridge can be configured through environment variables or a `.env` file:
 | `TAIGA_API_URL` | Base URL for the Taiga API | http://localhost:9000 |
 | `TAIGA_USERNAME` | Taiga username for auto-authentication | (none) |
 | `TAIGA_PASSWORD` | Taiga password for auto-authentication | (none) |
-| `TAIGA_TRANSPORT` | Transport mode (stdio or sse) | stdio |
+| `TAIGA_TRANSPORT` | Transport mode (stdio, sse, or streamable-http) | stdio |
+| `MCP_HOST` | Bind address for SSE/HTTP transport. Use `0.0.0.0` for Docker. | 127.0.0.1 |
+| `MCP_PORT` | Listen port for SSE/HTTP transport | 8000 |
 | `LOG_LEVEL` | Logging level | INFO |
 
 Create a `.env` file in the project root to set these values:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.2.3"
+version = "1.3.0"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.2.1"
+version = "1.2.2"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.2.2"
+version = "1.2.3"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/src/server.py
+++ b/src/server.py
@@ -2011,6 +2011,92 @@ def create_wiki_page(
     return _filter_response(result, "wiki_page", verbosity)
 
 
+@mcp.tool(
+    "get_wiki_page_by_slug",
+    description="Gets a wiki page by its slug within a project. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+)
+def get_wiki_page_by_slug(
+    project_id: int, slug: str, session_id: Optional[str] = None, verbosity: str = "standard"
+) -> Dict[str, Any]:
+    """Retrieves wiki page details by slug within a project."""
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing get_wiki_page_by_slug '{slug}' in project {project_id} for session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    result = _execute_taiga_operation(
+        "get_wiki_page_by_slug",
+        lambda: taiga_client_wrapper.api.wiki.get_by_slug(slug=slug, project=project_id),
+        f"wiki page slug '{slug}' in project {project_id}",
+    )
+    if not result:
+        raise ValueError(f"Wiki page with slug '{slug}' not found in project {project_id}")
+    return _filter_response(result, "wiki_page", verbosity)
+
+
+@mcp.tool(
+    "update_wiki_page",
+    description="Updates an existing wiki page. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+)
+def update_wiki_page(
+    wiki_page_id: int,
+    kwargs: Any = None,
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
+) -> Dict[str, Any]:
+    """Updates a wiki page. Pass fields to update as kwargs JSON string (e.g., {"content": "New content", "slug": "new-slug"})."""
+    actual_session_id = _get_session_id(session_id)
+    parsed_kwargs = _validate_kwargs("wiki_page", _parse_mcp_kwargs({"kwargs": kwargs}))
+    logger.info(
+        f"Executing update_wiki_page ID {wiki_page_id} for session {actual_session_id[:8]} with data: {parsed_kwargs}"
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+    try:
+        if not parsed_kwargs:
+            logger.info(f"No fields provided for update on wiki page {wiki_page_id}")
+            result = taiga_client_wrapper.api.wiki.get(wiki_page_id)
+            return _filter_response(result, "wiki_page", verbosity)
+
+        # Get current wiki page data to retrieve version
+        current_page = taiga_client_wrapper.api.wiki.get(wiki_page_id)
+        version = current_page.get("version")
+        if not version:
+            raise ValueError(f"Could not determine version for wiki page {wiki_page_id}")
+
+        # Use edit method for partial updates
+        updated_page = taiga_client_wrapper.api.wiki.edit(
+            wiki_page_id=wiki_page_id, version=version, data=parsed_kwargs
+        )
+        logger.info(f"Wiki page {wiki_page_id} update request sent.")
+        return _filter_response(updated_page, "wiki_page", verbosity)
+    except TaigaException as e:
+        logger.error(f"Taiga API error updating wiki page {wiki_page_id}: {e}", exc_info=False)
+        raise e
+    except Exception as e:
+        logger.error(f"Unexpected error updating wiki page {wiki_page_id}: {e}", exc_info=True)
+        raise RuntimeError(f"Server error updating wiki page: {e}")
+
+
+@mcp.tool(
+    "delete_wiki_page",
+    description="Deletes a wiki page by its ID. Uses default session if session_id not provided.",
+)
+def delete_wiki_page(wiki_page_id: int, session_id: Optional[str] = None) -> Dict[str, Any]:
+    """Deletes a wiki page by ID."""
+    actual_session_id = _get_session_id(session_id)
+    logger.warning(
+        f"Executing delete_wiki_page ID {wiki_page_id} for session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_delete():
+        taiga_client_wrapper.api.wiki.delete(wiki_page_id=wiki_page_id)
+        return {"status": "deleted", "wiki_page_id": wiki_page_id}
+
+    return _execute_taiga_operation("delete_wiki_page", do_delete, f"wiki page {wiki_page_id}")
+
+
 # --- Session Management Tools ---
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -397,12 +397,21 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
 
 
 # --- MCP Server Definition ---
+_mcp_port_str = os.environ.get("MCP_PORT", "8000")
+try:
+    _mcp_port = int(_mcp_port_str)
+except ValueError:
+    logger.error(
+        f"Invalid MCP_PORT value '{_mcp_port_str}', must be a number. Falling back to 8000."
+    )
+    _mcp_port = 8000
+
 mcp = FastMCP(
     "Taiga Bridge",
     dependencies=["pytaigaclient"],
     lifespan=server_lifespan,
     host=os.environ.get("MCP_HOST", "127.0.0.1"),
-    port=int(os.environ.get("MCP_PORT", "8000")),
+    port=_mcp_port,
 )
 
 # --- Helper Functions for Session Validation ---

--- a/src/server.py
+++ b/src/server.py
@@ -650,7 +650,7 @@ def list_projects(
     logger.info(f"Executing list_projects for session {actual_session_id[:8]}...")
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
     result = _execute_taiga_operation(
-        "list_projects", lambda: taiga_client_wrapper.api.projects.list()
+        "list_projects", lambda: taiga_client_wrapper.list_resources("projects")
     )
     return _filter_response(result, "project", verbosity)
 
@@ -833,7 +833,9 @@ def list_user_stories(
 
     result = _execute_taiga_operation(
         "list_user_stories",
-        lambda: taiga_client_wrapper.api.user_stories.list(project=project_id, **parsed_filters),
+        lambda: taiga_client_wrapper.list_resources(
+            "user_stories", project_id=project_id, **parsed_filters
+        ),
         f"project {project_id}",
     )
     return _filter_response(result, "user_story", verbosity)
@@ -1015,9 +1017,7 @@ def get_user_story_statuses(
 
     return _execute_taiga_operation(
         "get_user_story_statuses",
-        lambda: taiga_client_wrapper.api.userstory_statuses.list(
-            query_params={"project": project_id}
-        ),
+        lambda: taiga_client_wrapper.list_resources("userstory_statuses", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1043,13 +1043,11 @@ def list_tasks(
     )
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
 
-    # Workaround: pytaigaclient Tasks.list has a bug - passes query_params but TaigaClient.get expects params
-    # Use the underlying get method directly
-    query = {"project": project_id, **parsed_filters}
-
     result = _execute_taiga_operation(
         "list_tasks",
-        lambda: taiga_client_wrapper.api.get("/tasks", params=query),
+        lambda: taiga_client_wrapper.list_resources(
+            "tasks", project_id=project_id, **parsed_filters
+        ),
         f"project {project_id}",
     )
     return _filter_response(result, "task", verbosity)
@@ -1234,7 +1232,7 @@ def get_task_statuses(project_id: int, session_id: Optional[str] = None) -> List
 
     return _execute_taiga_operation(
         "get_task_statuses",
-        lambda: taiga_client_wrapper.api.task_statuses.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("task_statuses", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1260,11 +1258,11 @@ def list_issues(
     )
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
 
-    query = {"project": project_id, **parsed_filters}
-
     result = _execute_taiga_operation(
         "list_issues",
-        lambda: taiga_client_wrapper.api.issues.list(query_params=query),
+        lambda: taiga_client_wrapper.list_resources(
+            "issues", project_id=project_id, **parsed_filters
+        ),
         f"project {project_id}",
     )
     return _filter_response(result, "issue", verbosity)
@@ -1446,7 +1444,7 @@ def get_issue_statuses(project_id: int, session_id: Optional[str] = None) -> Lis
 
     return _execute_taiga_operation(
         "get_issue_statuses",
-        lambda: taiga_client_wrapper.api.issue_statuses.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("issue_statuses", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1465,7 +1463,7 @@ def get_issue_priorities(project_id: int, session_id: Optional[str] = None) -> L
 
     return _execute_taiga_operation(
         "get_issue_priorities",
-        lambda: taiga_client_wrapper.api.get("/priorities", params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("priorities", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1484,7 +1482,7 @@ def get_issue_severities(project_id: int, session_id: Optional[str] = None) -> L
 
     return _execute_taiga_operation(
         "get_issue_severities",
-        lambda: taiga_client_wrapper.api.get("/severities", params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("severities", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1503,7 +1501,7 @@ def get_issue_types(project_id: int, session_id: Optional[str] = None) -> List[D
 
     return _execute_taiga_operation(
         "get_issue_types",
-        lambda: taiga_client_wrapper.api.issue_types.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("issue_types", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1529,11 +1527,11 @@ def list_epics(
     )
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
 
-    query = {"project": project_id, **parsed_filters}
-
     result = _execute_taiga_operation(
         "list_epics",
-        lambda: taiga_client_wrapper.api.epics.list(query_params=query),
+        lambda: taiga_client_wrapper.list_resources(
+            "epics", project_id=project_id, **parsed_filters
+        ),
         f"project {project_id}",
     )
     return _filter_response(result, "epic", verbosity)
@@ -1739,7 +1737,7 @@ def list_milestones(
 
     result = _execute_taiga_operation(
         "list_milestones",
-        lambda: taiga_client_wrapper.api.milestones.list(project=project_id),
+        lambda: taiga_client_wrapper.list_resources("milestones", project_id=project_id),
         f"project {project_id}",
     )
     return _filter_response(result, "milestone", verbosity)
@@ -1882,7 +1880,7 @@ def get_project_members(
 
     result = _execute_taiga_operation(
         "get_project_members",
-        lambda: taiga_client_wrapper.api.memberships.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("memberships", project_id=project_id),
         f"project {project_id}",
     )
     return _filter_response(result, "member", verbosity)
@@ -1938,7 +1936,7 @@ def list_wiki_pages(
 
     result = _execute_taiga_operation(
         "list_wiki_pages",
-        lambda: taiga_client_wrapper.api.wiki.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("wiki", project_id=project_id),
         f"project {project_id}",
     )
     return _filter_response(result, "wiki_page", verbosity)

--- a/src/server.py
+++ b/src/server.py
@@ -2,6 +2,8 @@
 import json
 import logging
 import logging.config
+import os
+import sys
 import uuid
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, List, Optional
@@ -2162,6 +2164,45 @@ def list_comments(
     return _execute_taiga_operation("list_comments", do_list_comments, f"{object_type} {object_id}")
 
 
+VALID_TRANSPORTS = ("stdio", "sse", "streamable-http")
+
+
+def _resolve_transport(argv: list[str] | None = None, env: dict[str, str] | None = None) -> str:
+    """Determine the MCP transport from CLI flags or environment variable.
+
+    Priority: CLI flags (--sse, --streamable-http) > TAIGA_TRANSPORT env var > default (stdio).
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv).
+        env: Environment variables (defaults to os.environ).
+
+    Returns:
+        The transport name to use.
+    """
+    if argv is None:
+        argv = sys.argv
+    if env is None:
+        env = dict(os.environ)
+
+    if "--sse" in argv:
+        return "sse"
+    if "--streamable-http" in argv:
+        return "streamable-http"
+
+    env_transport = env.get("TAIGA_TRANSPORT", "").lower()
+    if env_transport in VALID_TRANSPORTS:
+        return env_transport
+    if env_transport:
+        logger.warning(
+            f"Unknown TAIGA_TRANSPORT value '{env_transport}', falling back to stdio. "
+            f"Valid values: {', '.join(VALID_TRANSPORTS)}"
+        )
+
+    return "stdio"
+
+
 # --- Run the server ---
 if __name__ == "__main__":
-    mcp.run()
+    transport = _resolve_transport()
+    logger.info(f"Starting server with {transport} transport")
+    mcp.run(transport=transport)

--- a/src/server.py
+++ b/src/server.py
@@ -397,7 +397,13 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
 
 
 # --- MCP Server Definition ---
-mcp = FastMCP("Taiga Bridge", dependencies=["pytaigaclient"], lifespan=server_lifespan)
+mcp = FastMCP(
+    "Taiga Bridge",
+    dependencies=["pytaigaclient"],
+    lifespan=server_lifespan,
+    host=os.environ.get("MCP_HOST", "127.0.0.1"),
+    port=int(os.environ.get("MCP_PORT", "8000")),
+)
 
 # --- Helper Functions for Session Validation ---
 

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -7,13 +7,25 @@ from pytaigaclient.exceptions import TaigaException
 
 logger = logging.getLogger(__name__)
 
-# Resources that use the `project=X` keyword argument pattern
-_PROJECT_KWARG_RESOURCES = {"user_stories", "milestones"}
+# Endpoint mapping for all listable resources
+_RESOURCE_ENDPOINTS = {
+    "projects": "/projects",
+    "user_stories": "/userstories",
+    "tasks": "/tasks",
+    "issues": "/issues",
+    "epics": "/epics",
+    "milestones": "/milestones",
+    "wiki": "/wiki",
+    "memberships": "/memberships",
+    "userstory_statuses": "/userstory-statuses",
+    "task_statuses": "/task-statuses",
+    "issue_statuses": "/issue-statuses",
+    "issue_types": "/issue-types",
+    "priorities": "/priorities",
+    "severities": "/severities",
+}
 
-# Resources that require raw API calls due to pytaigaclient bugs
-_RAW_API_RESOURCES = {"tasks"}
-
-# All other resources use query_params={"project": X} pattern
+_NO_PAGINATION_HEADERS = {"x-disable-pagination": "True"}
 
 
 class TaigaClientWrapper:
@@ -80,7 +92,10 @@ class TaigaClientWrapper:
         self, resource_type: str, project_id: Optional[int] = None, **filters
     ) -> List[Dict[str, Any]]:
         """
-        Unified interface for listing resources, hiding pytaigaclient inconsistencies.
+        Unified interface for listing resources via raw API with pagination disabled.
+
+        Uses the x-disable-pagination header to bypass Taiga's default PAGE_SIZE=30
+        limit, ensuring all results are returned in a single request.
 
         Args:
             resource_type: The type of resource (e.g., 'user_stories', 'tasks', 'issues')
@@ -89,34 +104,16 @@ class TaigaClientWrapper:
 
         Returns:
             List of resource dictionaries
-
-        Note:
-            pytaigaclient has inconsistent APIs:
-            - user_stories, milestones use: list(project=X, **filters)
-            - tasks use raw API due to bug: api.get("/tasks", params={...})
-            - issues, epics, etc use: list(query_params={...})
         """
         self._ensure_authenticated()
-
-        if resource_type in _RAW_API_RESOURCES:
-            # Workaround: pytaigaclient Tasks.list passes query_params but
-            # TaigaClient.get expects params - use raw API call
-            # See: https://github.com/talhaorak/pyTaigaClient/issues/XXX
-            params = {"project": project_id, **filters} if project_id else filters
-            endpoint = f"/{resource_type}"
-            return self.api.get(endpoint, params=params)
-
-        resource = getattr(self.api, resource_type, None)
-        if resource is None:
-            raise ValueError(f"Unknown resource type: {resource_type}")
-
-        if resource_type in _PROJECT_KWARG_RESOURCES:
-            # These resources accept project as a keyword argument
-            if project_id:
-                return resource.list(project=project_id, **filters)
-            else:
-                return resource.list(**filters)
-        else:
-            # Default pattern: use query_params dict
-            query = {"project": project_id, **filters} if project_id else filters
-            return resource.list(query_params=query)
+        endpoint = _RESOURCE_ENDPOINTS.get(resource_type)
+        if endpoint is None:
+            raise ValueError(
+                f"Unknown resource type: {resource_type}. Valid: {sorted(_RESOURCE_ENDPOINTS)}"
+            )
+        params = {}
+        if project_id is not None:
+            params["project"] = project_id
+        params.update(filters)
+        result = self.api.get(endpoint, params=params, headers=_NO_PAGINATION_HEADERS)
+        return result if isinstance(result, list) else []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -1071,6 +1072,75 @@ class TestTaigaTools:
         assert result["id"] == 400
         assert result["slug"] == "home"
         mock_client.api.wiki.get.assert_called_once_with(400)
+
+    def test_get_wiki_page_by_slug(self, session_setup):
+        """Test get_wiki_page_by_slug."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.get_by_slug.return_value = {
+            "id": 400,
+            "slug": "home",
+            "content": "# Welcome",
+            "project": 123,
+            "version": 1,
+        }
+        result = src.server.get_wiki_page_by_slug(123, "home", session_id)
+        assert result["id"] == 400
+        assert result["slug"] == "home"
+        mock_client.api.wiki.get_by_slug.assert_called_once_with(slug="home", project=123)
+
+    def test_get_wiki_page_by_slug_not_found(self, session_setup):
+        """Test get_wiki_page_by_slug raises ValueError when not found."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.get_by_slug.return_value = {}
+        with pytest.raises(ValueError, match="not found"):
+            src.server.get_wiki_page_by_slug(123, "nonexistent", session_id)
+
+    def test_update_wiki_page(self, session_setup):
+        """Test update_wiki_page."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.get.return_value = {
+            "id": 400,
+            "slug": "home",
+            "content": "# Welcome",
+            "project": 123,
+            "version": 1,
+        }
+        mock_client.api.wiki.edit.return_value = {
+            "id": 400,
+            "slug": "home",
+            "content": "# Updated",
+            "project": 123,
+            "version": 2,
+        }
+        result = src.server.update_wiki_page(400, json.dumps({"content": "# Updated"}), session_id)
+        assert result["content"] == "# Updated"
+        assert result["version"] == 2
+        mock_client.api.wiki.edit.assert_called_once_with(
+            wiki_page_id=400, version=1, data={"content": "# Updated"}
+        )
+
+    def test_update_wiki_page_no_kwargs(self, session_setup):
+        """Test update_wiki_page with no kwargs returns current state."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.get.return_value = {
+            "id": 400,
+            "slug": "home",
+            "content": "# Welcome",
+            "project": 123,
+            "version": 1,
+        }
+        result = src.server.update_wiki_page(400, None, session_id)
+        assert result["id"] == 400
+        mock_client.api.wiki.edit.assert_not_called()
+
+    def test_delete_wiki_page(self, session_setup):
+        """Test delete_wiki_page."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.delete.return_value = None
+        result = src.server.delete_wiki_page(400, session_id)
+        assert result["status"] == "deleted"
+        assert result["wiki_page_id"] == 400
+        mock_client.api.wiki.delete.assert_called_once_with(wiki_page_id=400)
 
     # ─── Verbosity tests for various tools ───────────────────────────
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -211,16 +211,17 @@ class TestTaigaTools:
     def test_list_projects(self, session_setup):
         """Test list_projects functionality"""
         session_id, mock_client = session_setup
-        mock_client.api.projects.list.return_value = [{"id": 123, "name": "Test Project"}]
+        mock_client.list_resources.return_value = [{"id": 123, "name": "Test Project"}]
         projects = src.server.list_projects(session_id)
         assert len(projects) == 1
         assert projects[0]["name"] == "Test Project"
         assert projects[0]["id"] == 123
+        mock_client.list_resources.assert_called_once_with("projects")
 
     def test_list_all_projects(self, session_setup):
         """Test list_all_projects delegates to list_projects."""
         session_id, mock_client = session_setup
-        mock_client.api.projects.list.return_value = [{"id": 1, "name": "P1"}]
+        mock_client.list_resources.return_value = [{"id": 1, "name": "P1"}]
         projects = src.server.list_all_projects(session_id)
         assert len(projects) == 1
 
@@ -333,18 +334,18 @@ class TestTaigaTools:
     def test_list_user_stories(self, session_setup):
         """Test list_user_stories functionality"""
         session_id, mock_client = session_setup
-        mock_client.api.user_stories.list.return_value = [{"id": 456, "subject": "Test User Story"}]
+        mock_client.list_resources.return_value = [{"id": 456, "subject": "Test User Story"}]
         stories = src.server.list_user_stories(123, "{}", session_id)
         assert len(stories) == 1
         assert stories[0]["subject"] == "Test User Story"
-        mock_client.api.user_stories.list.assert_called_once_with(project=123)
+        mock_client.list_resources.assert_called_once_with("user_stories", project_id=123)
 
     def test_list_user_stories_with_filters(self, session_setup):
         """Test list_user_stories with filters."""
         session_id, mock_client = session_setup
-        mock_client.api.user_stories.list.return_value = [{"id": 1, "subject": "Filtered"}]
+        mock_client.list_resources.return_value = [{"id": 1, "subject": "Filtered"}]
         src.server.list_user_stories(123, '{"status": 1}', session_id)
-        mock_client.api.user_stories.list.assert_called_once_with(project=123, status=1)
+        mock_client.list_resources.assert_called_once_with("user_stories", project_id=123, status=1)
 
     def test_create_user_story(self, session_setup):
         """Test create_user_story functionality"""
@@ -473,35 +474,31 @@ class TestTaigaTools:
     def test_get_user_story_statuses(self, session_setup):
         """Test get_user_story_statuses."""
         session_id, mock_client = session_setup
-        mock_client.api.userstory_statuses.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "New"},
             {"id": 2, "name": "In Progress"},
         ]
         result = src.server.get_user_story_statuses(123, session_id)
         assert len(result) == 2
-        mock_client.api.userstory_statuses.list.assert_called_once_with(
-            query_params={"project": 123}
-        )
+        mock_client.list_resources.assert_called_once_with("userstory_statuses", project_id=123)
 
     # ─── Task tools tests ────────────────────────────────────────────
 
     def test_list_tasks(self, session_setup):
         """Test list_tasks functionality"""
         session_id, mock_client = session_setup
-        mock_client.api.get.return_value = [{"id": 789, "subject": "Test Task"}]
+        mock_client.list_resources.return_value = [{"id": 789, "subject": "Test Task"}]
         tasks = src.server.list_tasks(123, "{}", session_id)
         assert len(tasks) == 1
         assert tasks[0]["subject"] == "Test Task"
-        mock_client.api.get.assert_called_once_with("/tasks", params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("tasks", project_id=123)
 
     def test_list_tasks_with_filters(self, session_setup):
         """Test list_tasks with filters."""
         session_id, mock_client = session_setup
-        mock_client.api.get.return_value = [{"id": 1, "subject": "Filtered"}]
+        mock_client.list_resources.return_value = [{"id": 1, "subject": "Filtered"}]
         src.server.list_tasks(123, '{"milestone": 5}', session_id)
-        mock_client.api.get.assert_called_once_with(
-            "/tasks", params={"project": 123, "milestone": 5}
-        )
+        mock_client.list_resources.assert_called_once_with("tasks", project_id=123, milestone=5)
 
     def test_create_task(self, session_setup):
         """Test create_task."""
@@ -625,20 +622,18 @@ class TestTaigaTools:
     def test_list_issues(self, session_setup):
         """Test list_issues."""
         session_id, mock_client = session_setup
-        mock_client.api.issues.list.return_value = [{"id": 100, "subject": "Bug"}]
+        mock_client.list_resources.return_value = [{"id": 100, "subject": "Bug"}]
         result = src.server.list_issues(123, "{}", session_id)
         assert len(result) == 1
         assert result[0]["subject"] == "Bug"
-        mock_client.api.issues.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("issues", project_id=123)
 
     def test_list_issues_with_filters(self, session_setup):
         """Test list_issues with filters."""
         session_id, mock_client = session_setup
-        mock_client.api.issues.list.return_value = []
+        mock_client.list_resources.return_value = []
         src.server.list_issues(123, '{"priority": 3}', session_id)
-        mock_client.api.issues.list.assert_called_once_with(
-            query_params={"project": 123, "priority": 3}
-        )
+        mock_client.list_resources.assert_called_once_with("issues", project_id=123, priority=3)
 
     def test_create_issue(self, session_setup):
         """Test create_issue."""
@@ -764,18 +759,18 @@ class TestTaigaTools:
     def test_get_issue_statuses(self, session_setup):
         """Test get_issue_statuses."""
         session_id, mock_client = session_setup
-        mock_client.api.issue_statuses.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "New"},
             {"id": 2, "name": "Closed"},
         ]
         result = src.server.get_issue_statuses(123, session_id)
         assert len(result) == 2
-        mock_client.api.issue_statuses.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("issue_statuses", project_id=123)
 
     def test_get_issue_priorities(self, session_setup):
-        """Test get_issue_priorities uses direct GET with /priorities endpoint."""
+        """Test get_issue_priorities."""
         session_id, mock_client = session_setup
-        mock_client.api.get.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "Low"},
             {"id": 2, "name": "Normal"},
             {"id": 3, "name": "High"},
@@ -783,13 +778,12 @@ class TestTaigaTools:
         result = src.server.get_issue_priorities(123, session_id)
         assert len(result) == 3
         assert result[0]["name"] == "Low"
-        # Verify it uses the direct GET call, not issue_priorities.list
-        mock_client.api.get.assert_called_once_with("/priorities", params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("priorities", project_id=123)
 
     def test_get_issue_severities(self, session_setup):
-        """Test get_issue_severities uses direct GET with /severities endpoint."""
+        """Test get_issue_severities."""
         session_id, mock_client = session_setup
-        mock_client.api.get.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "Wishlist"},
             {"id": 2, "name": "Minor"},
             {"id": 3, "name": "Normal"},
@@ -797,39 +791,36 @@ class TestTaigaTools:
         result = src.server.get_issue_severities(123, session_id)
         assert len(result) == 3
         assert result[0]["name"] == "Wishlist"
-        # Verify it uses the direct GET call, not issue_severities.list
-        mock_client.api.get.assert_called_once_with("/severities", params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("severities", project_id=123)
 
     def test_get_issue_types(self, session_setup):
         """Test get_issue_types."""
         session_id, mock_client = session_setup
-        mock_client.api.issue_types.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "Bug"},
             {"id": 2, "name": "Enhancement"},
         ]
         result = src.server.get_issue_types(123, session_id)
         assert len(result) == 2
-        mock_client.api.issue_types.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("issue_types", project_id=123)
 
     # ─── Epic tools tests ────────────────────────────────────────────
 
     def test_list_epics(self, session_setup):
         """Test list_epics."""
         session_id, mock_client = session_setup
-        mock_client.api.epics.list.return_value = [{"id": 200, "subject": "Epic 1"}]
+        mock_client.list_resources.return_value = [{"id": 200, "subject": "Epic 1"}]
         result = src.server.list_epics(123, "{}", session_id)
         assert len(result) == 1
         assert result[0]["subject"] == "Epic 1"
-        mock_client.api.epics.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("epics", project_id=123)
 
     def test_list_epics_with_filters(self, session_setup):
         """Test list_epics with filters."""
         session_id, mock_client = session_setup
-        mock_client.api.epics.list.return_value = []
+        mock_client.list_resources.return_value = []
         src.server.list_epics(123, '{"status": 2}', session_id)
-        mock_client.api.epics.list.assert_called_once_with(
-            query_params={"project": 123, "status": 2}
-        )
+        mock_client.list_resources.assert_called_once_with("epics", project_id=123, status=2)
 
     def test_create_epic(self, session_setup):
         """Test create_epic."""
@@ -944,13 +935,13 @@ class TestTaigaTools:
     def test_list_milestones(self, session_setup):
         """Test list_milestones."""
         session_id, mock_client = session_setup
-        mock_client.api.milestones.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 300, "name": "Sprint 1", "slug": "sprint-1", "project": 123}
         ]
         result = src.server.list_milestones(123, session_id)
         assert len(result) == 1
         assert result[0]["name"] == "Sprint 1"
-        mock_client.api.milestones.list.assert_called_once_with(project=123)
+        mock_client.list_resources.assert_called_once_with("milestones", project_id=123)
 
     def test_create_milestone(self, session_setup):
         """Test create_milestone."""
@@ -1027,13 +1018,13 @@ class TestTaigaTools:
     def test_get_project_members(self, session_setup):
         """Test get_project_members."""
         session_id, mock_client = session_setup
-        mock_client.api.memberships.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "user": 10, "full_name": "John Doe", "role_name": "Admin"}
         ]
         result = src.server.get_project_members(123, session_id)
         assert len(result) == 1
         assert result[0]["full_name"] == "John Doe"
-        mock_client.api.memberships.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("memberships", project_id=123)
 
     def test_invite_project_user(self, session_setup):
         """Test invite_project_user."""
@@ -1060,11 +1051,11 @@ class TestTaigaTools:
     def test_list_wiki_pages(self, session_setup):
         """Test list_wiki_pages."""
         session_id, mock_client = session_setup
-        mock_client.api.wiki.list.return_value = [{"id": 400, "slug": "home", "project": 123}]
+        mock_client.list_resources.return_value = [{"id": 400, "slug": "home", "project": 123}]
         result = src.server.list_wiki_pages(123, session_id)
         assert len(result) == 1
         assert result[0]["slug"] == "home"
-        mock_client.api.wiki.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("wiki", project_id=123)
 
     def test_get_wiki_page(self, session_setup):
         """Test get_wiki_page."""
@@ -1086,7 +1077,7 @@ class TestTaigaTools:
     def test_list_projects_verbosity_minimal(self, session_setup):
         """Test list_projects with minimal verbosity."""
         session_id, mock_client = session_setup
-        mock_client.api.projects.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "P1", "slug": "p1", "description": "Long desc", "version": 1}
         ]
         result = src.server.list_projects(session_id, verbosity="minimal")
@@ -1440,42 +1431,60 @@ class TestTaigaClientWrapper:
         with pytest.raises(PermissionError):
             wrapper.list_resources("projects")
 
-    def test_list_resources_raw_api(self):
-        """Test list_resources uses raw API for tasks."""
+    def test_list_resources_sends_disable_pagination_header(self):
+        """Test list_resources sends x-disable-pagination header."""
         wrapper = TaigaClientWrapper(host="http://test:9000")
         wrapper.api = MagicMock()
         wrapper.api.auth_token = "test-token"
         wrapper.api.get.return_value = [{"id": 1}]
-        result = wrapper.list_resources("tasks", project_id=123)
-        wrapper.api.get.assert_called_once_with("/tasks", params={"project": 123})
-        assert result == [{"id": 1}]
+        wrapper.list_resources("projects")
+        wrapper.api.get.assert_called_once_with(
+            "/projects", params={}, headers={"x-disable-pagination": "True"}
+        )
 
-    def test_list_resources_project_kwarg(self):
-        """Test list_resources uses project kwarg for user_stories."""
+    def test_list_resources_endpoint_mapping(self):
+        """Test list_resources maps resource types to correct endpoints."""
+        from src.taiga_client import _RESOURCE_ENDPOINTS
+
         wrapper = TaigaClientWrapper(host="http://test:9000")
         wrapper.api = MagicMock()
         wrapper.api.auth_token = "test-token"
-        wrapper.api.user_stories.list.return_value = [{"id": 1}]
-        result = wrapper.list_resources("user_stories", project_id=123)
-        wrapper.api.user_stories.list.assert_called_once_with(project=123)
-        assert result == [{"id": 1}]
+        wrapper.api.get.return_value = []
+        for resource_type, endpoint in _RESOURCE_ENDPOINTS.items():
+            wrapper.api.get.reset_mock()
+            wrapper.list_resources(resource_type)
+            call_args = wrapper.api.get.call_args
+            assert call_args[0][0] == endpoint, f"{resource_type} -> {endpoint}"
 
-    def test_list_resources_query_params(self):
-        """Test list_resources uses query_params for issues."""
+    def test_list_resources_with_filters(self):
+        """Test list_resources passes filters as params."""
         wrapper = TaigaClientWrapper(host="http://test:9000")
         wrapper.api = MagicMock()
         wrapper.api.auth_token = "test-token"
-        wrapper.api.issues.list.return_value = [{"id": 1}]
-        result = wrapper.list_resources("issues", project_id=123)
-        wrapper.api.issues.list.assert_called_once_with(query_params={"project": 123})
+        wrapper.api.get.return_value = [{"id": 1}]
+        result = wrapper.list_resources("issues", project_id=123, status=2)
+        wrapper.api.get.assert_called_once_with(
+            "/issues",
+            params={"project": 123, "status": 2},
+            headers={"x-disable-pagination": "True"},
+        )
         assert result == [{"id": 1}]
+
+    def test_list_resources_no_project_id(self):
+        """Test list_resources omits project key when project_id is None."""
+        wrapper = TaigaClientWrapper(host="http://test:9000")
+        wrapper.api = MagicMock()
+        wrapper.api.auth_token = "test-token"
+        wrapper.api.get.return_value = [{"id": 1}]
+        wrapper.list_resources("projects")
+        call_params = wrapper.api.get.call_args[1]["params"]
+        assert "project" not in call_params
 
     def test_list_resources_unknown_type(self):
         """Test list_resources raises for unknown resource type."""
         wrapper = TaigaClientWrapper(host="http://test:9000")
         wrapper.api = MagicMock()
         wrapper.api.auth_token = "test-token"
-        wrapper.api.nonexistent = None
         with pytest.raises(ValueError, match="Unknown resource type"):
             wrapper.list_resources("nonexistent")
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,50 @@
+"""Tests for transport resolution logic."""
+
+from src.server import _resolve_transport
+
+
+class TestResolveTransport:
+    """Tests for _resolve_transport()."""
+
+    def test_default_is_stdio(self):
+        assert _resolve_transport(argv=[], env={}) == "stdio"
+
+    def test_cli_sse_flag(self):
+        assert _resolve_transport(argv=["server.py", "--sse"], env={}) == "sse"
+
+    def test_cli_streamable_http_flag(self):
+        assert (
+            _resolve_transport(argv=["server.py", "--streamable-http"], env={}) == "streamable-http"
+        )
+
+    def test_env_var_sse(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "sse"}) == "sse"
+
+    def test_env_var_streamable_http(self):
+        assert (
+            _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "streamable-http"})
+            == "streamable-http"
+        )
+
+    def test_env_var_stdio_explicit(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "stdio"}) == "stdio"
+
+    def test_env_var_case_insensitive(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "SSE"}) == "sse"
+
+    def test_cli_takes_precedence_over_env(self):
+        assert (
+            _resolve_transport(
+                argv=["server.py", "--sse"], env={"TAIGA_TRANSPORT": "streamable-http"}
+            )
+            == "sse"
+        )
+
+    def test_unknown_env_var_falls_back_to_stdio(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "websocket"}) == "stdio"
+
+    def test_empty_env_var_falls_back_to_stdio(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": ""}) == "stdio"
+
+    def test_no_env_var_falls_back_to_stdio(self):
+        assert _resolve_transport(argv=[], env={"OTHER_VAR": "value"}) == "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.1.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- Add `update_wiki_page` tool with optimistic concurrency control (fetch version, then `wiki.edit()`)
- Add `delete_wiki_page` tool following the existing delete pattern
- Add `get_wiki_page_by_slug` tool using pytaigaclient's native `wiki.get_by_slug()`
- Completes wiki CRUD parity with other resource types (projects, epics, user stories, tasks, issues)

Also includes two prior fixes not yet on master:
- `fix: bind SSE/HTTP server to MCP_HOST for Docker compatibility`
- `fix: validate MCP_PORT and document MCP_HOST/MCP_PORT env vars`

## Test plan
- [x] 5 new unit tests added (get_by_slug, get_by_slug_not_found, update, update_no_kwargs, delete)
- [x] All 149 tests pass
- [x] ruff lint + format clean
- [x] Pre-commit hooks pass