### PR TITLE
feat: add bulk operations tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- version list -->
 
+## v1.2.2 (2026-03-15)
+
+### Bug Fixes
+
+- **server**: Handle invalid JSON gracefully in _parse_mcp_kwargs
+  ([`355e6a8`](https://github.com/TETRA-2023/pytaiga-mcp/commit/355e6a8c8da95c209fc72d5d3e214c929ec6fb05))
+
+- **server**: Set default session on login and use correct slug lookup
+  ([`2148586`](https://github.com/TETRA-2023/pytaiga-mcp/commit/2148586bdf60fa93b5ba9342df41d36a42a8c732))
+
+### Documentation
+
+- Update README for Python 3.12, GHCR image, pre-commit hooks
+  ([`d28ffc2`](https://github.com/TETRA-2023/pytaiga-mcp/commit/d28ffc2db91e2f4384690025e75370a070382327))
+
+### Testing
+
+- Add filters key path coverage for _parse_mcp_kwargs
+  ([`30681e5`](https://github.com/TETRA-2023/pytaiga-mcp/commit/30681e5b0c15c6a8badc95f3619a4df3acb083dc))
+
+- Remove duplicate get_project_by_slug test
+  ([`662438c`](https://github.com/TETRA-2023/pytaiga-mcp/commit/662438ce8493eaeded0c7e87d7b122df0268c394))
+
+
 ## v1.2.1 (2026-03-15)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.5.0 (2026-03-26)
+
+### Features
+
+- Add global search tool and CLAUDE.md
+  ([`0c9981b`](https://github.com/TETRA-2023/pytaiga-mcp/commit/0c9981bde6bd41bd6b3f7b2f634fee1345a3fa80))
+
+
 ## v1.4.0 (2026-03-24)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- version list -->
 
+## v1.4.0 (2026-03-24)
+
+### Bug Fixes
+
+- Bind SSE/HTTP server to MCP_HOST for Docker compatibility
+  ([`01edeb4`](https://github.com/TETRA-2023/pytaiga-mcp/commit/01edeb4b8371b7b57b6045dda2ac10e50dc6f899))
+
+- Validate MCP_PORT and document MCP_HOST/MCP_PORT env vars
+  ([`09c10a2`](https://github.com/TETRA-2023/pytaiga-mcp/commit/09c10a263dd630cfcee4d88b20ba78ea52863eea))
+
+### Features
+
+- Add update, delete, and get-by-slug wiki page tools
+  ([`f43e346`](https://github.com/TETRA-2023/pytaiga-mcp/commit/f43e346577a1cf747d68497b16cb8f58c4005e0b))
+
+
 ## v1.3.1 (2026-03-24)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.6.0 (2026-03-26)
+
+### Features
+
+- Add project tag management tools
+  ([`7d425c1`](https://github.com/TETRA-2023/pytaiga-mcp/commit/7d425c15ee69c4dbe3b046ab98a900fa8bcd3716))
+
+
 ## v1.5.0 (2026-03-26)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.7.0 (2026-03-26)
+
+### Features
+
+- Add comment edit/delete/undelete and version history tools
+  ([`174de29`](https://github.com/TETRA-2023/pytaiga-mcp/commit/174de29d96d8ab4d6ccac709664cabe24b41222b))
+
+
 ## v1.6.0 (2026-03-26)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.8.0 (2026-03-26)
+
+### Features
+
+- Add full history/audit trail tool
+  ([`881212b`](https://github.com/TETRA-2023/pytaiga-mcp/commit/881212b9f665f38f48815d7237c72cf46207da23))
+
+
 ## v1.7.0 (2026-03-26)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.3.1 (2026-03-24)
+
+### Bug Fixes
+
+- Bind SSE/HTTP server to MCP_HOST for Docker compatibility
+  ([`c80d1b0`](https://github.com/TETRA-2023/pytaiga-mcp/commit/c80d1b0d49bebbec15d679f337ac4e035db12640))
+
+
 ## v1.3.0 (2026-03-24)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.2.3 (2026-03-16)
+
+### Bug Fixes
+
+- Disable pagination on all list calls via x-disable-pagination header
+  ([`ce35ae4`](https://github.com/TETRA-2023/pytaiga-mcp/commit/ce35ae46fc228633552211c00a6e392d405fa8c1))
+
+
 ## v1.2.2 (2026-03-15)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.3.0 (2026-03-24)
+
+### Features
+
+- Add SSE and streamable-http transport support
+  ([`ede5586`](https://github.com/TETRA-2023/pytaiga-mcp/commit/ede5586c526b3cfde73e1d8f7c821a6d37b25434))
+
+
 ## v1.2.3 (2026-03-16)
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md — pytaiga-mcp
+
+## Project Overview
+
+MCP (Model Context Protocol) server bridging AI assistants with the Taiga project management API. Built on FastMCP with the `pytaigaclient` library.
+
+- **Package**: `mcp-taiga-bridge`
+- **Python**: >= 3.12
+- **Upstream**: `talhaorak/pytaiga-mcp` (origin: `TETRA-2023/pytaiga-mcp`)
+
+## Architecture
+
+```
+src/
+  server.py        — MCP tool definitions (all 64+ tools registered via @mcp.tool())
+  taiga_client.py  — TaigaClientWrapper: auth, raw API calls, pagination bypass
+  config.py        — Pydantic settings (env vars, SecretStr credentials)
+```
+
+- `server.py` is the main file (~2300 lines). Tools are grouped by resource type: auth, projects, user stories, tasks, issues, epics, milestones, wiki, memberships, comments.
+- `taiga_client.py` wraps `pytaigaclient.TaigaClient` and adds `list_resources()` with `x-disable-pagination` header.
+- Session management: `active_sessions` dict keyed by UUID (or `"default"` for auto-auth).
+
+## Development Setup
+
+```bash
+./install.sh --dev    # Install with dev dependencies (ruff, pytest, mypy, pre-commit)
+cp .env.example .env  # Configure TAIGA_API_URL, TAIGA_USERNAME, TAIGA_PASSWORD
+```
+
+## Running
+
+```bash
+./run.sh              # stdio transport (default)
+./run.sh --sse        # SSE transport
+# Or directly:
+uv run python src/server.py [--sse | --streamable-http]
+```
+
+Environment variables: `TAIGA_TRANSPORT`, `TAIGA_API_URL`, `TAIGA_USERNAME`, `TAIGA_PASSWORD`, `MCP_HOST`, `MCP_PORT`.
+
+## Testing
+
+```bash
+./run_unit_tests.sh                                        # Unit tests only
+uv run pytest tests/test_server.py -v                      # Unit tests
+uv run pytest tests/test_integration.py -v -m integration  # Integration tests (needs running Taiga)
+```
+
+Pre-commit hooks run ruff (lint + format) and unit tests automatically.
+
+## Code Conventions
+
+- **Linter/formatter**: ruff (line-length=100, target py312, rules: E, F, W, I)
+- **Commit messages**: Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, etc.) — used by `python-semantic-release` for auto-versioning
+- **Branch naming**: `feature/<name>`, `fix/<name>`
+- **Tool pattern**: Each Taiga resource follows a consistent CRUD pattern:
+  - `list_{resource}`, `create_{resource}`, `get_{resource}`, `get_{resource}_by_ref`, `update_{resource}`, `delete_{resource}`
+  - `assign_{resource}_to_user` / `unassign_{resource}_from_user` where applicable
+  - `get_{resource}_statuses` for status lookups
+- **Kwargs validation**: All create/update tools validate kwargs against `ALLOWED_KWARGS[resource_type]`
+- **Response filtering**: `verbosity` parameter ("minimal", "standard", "full") controls returned fields via `RESPONSE_FIELDS` dict
+- **Error handling**: All tools use `_execute_taiga_operation()` wrapper for consistent error handling
+- **Security**: Never log credentials. Use `SecretStr` for passwords. Validate kwargs against allowlists.
+
+## Key Design Decisions
+
+- Pagination disabled globally via `x-disable-pagination: True` header (Taiga default PAGE_SIZE=30 is too low)
+- Comments use raw HTTP (PATCH with version for optimistic concurrency, GET history for listing)
+- `link_user_story_to_epic` uses raw POST to `/epics/{id}/related_userstories`
+- `_COMMENT_TYPE_MAP` translates user-facing types to API path segments
+
+## Contributing
+
+Per CONTRIBUTING.md:
+1. Create feature branch (`feature/<name>`)
+2. Install dev dependencies (`./install.sh --dev`)
+3. Make changes following the code conventions above
+4. Run tests (`uv run pytest tests/test_server.py -v`)
+5. Ensure ruff passes (`uv run ruff check src/ && uv run ruff format --check src/`)
+6. Commit with conventional commit messages
+7. Open a Pull Request
+
+**Repository policy**: This is a maintained fork. All PRs must target `TETRA-2023/pytaiga-mcp`. Do not open PRs against the upstream repo (`talhaorak/pytaiga-mcp`) — contributions to upstream should be coordinated separately and manually by maintainers.
+
+**Branch retention**: Do not delete branches after merging. Merged branches are kept to facilitate cherry-picking and PR transfers to upstream.
+
+The project follows the Contributor Covenant Code of Conduct v2.0.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ The bridge can be configured through environment variables or a `.env` file:
 | `TAIGA_API_URL` | Base URL for the Taiga API | http://localhost:9000 |
 | `TAIGA_USERNAME` | Taiga username for auto-authentication | (none) |
 | `TAIGA_PASSWORD` | Taiga password for auto-authentication | (none) |
-| `TAIGA_TRANSPORT` | Transport mode (stdio or sse) | stdio |
+| `TAIGA_TRANSPORT` | Transport mode (stdio, sse, or streamable-http) | stdio |
+| `MCP_HOST` | Bind address for SSE/HTTP transport. Use `0.0.0.0` for Docker. | 127.0.0.1 |
+| `MCP_PORT` | Listen port for SSE/HTTP transport | 8000 |
 | `LOG_LEVEL` | Logging level | INFO |
 
 Create a `.env` file in the project root to set these values:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.3.0"
+version = "1.3.1"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.4.0"
+version = "1.5.0"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.7.0"
+version = "1.8.0"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.5.0"
+version = "1.6.0"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.3.1"
+version = "1.4.0"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.2.3"
+version = "1.3.0"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.6.0"
+version = "1.7.0"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.2.1"
+version = "1.2.2"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.2.2"
+version = "1.2.3"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/src/server.py
+++ b/src/server.py
@@ -172,6 +172,18 @@ _COMMENT_TYPE_MAP = {
     "epic": ("epics", "epic"),
 }
 
+# --- History Type Mapping ---
+# Maps user-facing type names to history path segments (superset of comment types, includes wiki)
+_HISTORY_TYPE_MAP = {
+    "issue": "issue",
+    "task": "task",
+    "user_story": "userstory",
+    "userstory": "userstory",
+    "epic": "epic",
+    "wiki": "wiki",
+    "wiki_page": "wiki",
+}
+
 # --- Response Field Filtering ---
 # Define which fields to include at each verbosity level per resource type
 # - 'minimal': Core identification fields only
@@ -2586,6 +2598,53 @@ def get_comment_versions(
         do_get_versions,
         f"{object_type} {object_id} comment {comment_id}",
     )
+
+
+# --- History / Audit Trail ---
+
+
+@mcp.tool()
+def get_history(
+    object_id: int,
+    object_type: str,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get the full change history (audit trail) for a Taiga object.
+
+    Returns all history entries including field changes, status transitions,
+    assignments, and comments.
+
+    Args:
+        object_id: The ID of the object
+        object_type: Type of object: 'issue', 'task', 'user_story', 'userstory',
+                     'epic', 'wiki', or 'wiki_page'
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict with 'object_type', 'object_id', and 'history' list of change entries.
+    """
+    if object_type not in _HISTORY_TYPE_MAP:
+        raise ValueError(
+            f"Invalid object_type '{object_type}'. "
+            f"Must be one of: {', '.join(sorted(_HISTORY_TYPE_MAP.keys()))}"
+        )
+
+    history_path = _HISTORY_TYPE_MAP[object_type]
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing get_history for {object_type} {object_id} session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_get_history():
+        result = taiga_client_wrapper.api.get(f"/history/{history_path}/{object_id}")
+        return {
+            "object_type": object_type,
+            "object_id": object_id,
+            "history": result if isinstance(result, list) else [],
+        }
+
+    return _execute_taiga_operation("get_history", do_get_history, f"{object_type} {object_id}")
 
 
 # --- Search ---

--- a/src/server.py
+++ b/src/server.py
@@ -2011,6 +2011,92 @@ def create_wiki_page(
     return _filter_response(result, "wiki_page", verbosity)
 
 
+@mcp.tool(
+    "get_wiki_page_by_slug",
+    description="Gets a wiki page by its slug within a project. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+)
+def get_wiki_page_by_slug(
+    project_id: int, slug: str, session_id: Optional[str] = None, verbosity: str = "standard"
+) -> Dict[str, Any]:
+    """Retrieves wiki page details by slug within a project."""
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing get_wiki_page_by_slug '{slug}' in project {project_id} for session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    result = _execute_taiga_operation(
+        "get_wiki_page_by_slug",
+        lambda: taiga_client_wrapper.api.wiki.get_by_slug(slug=slug, project=project_id),
+        f"wiki page slug '{slug}' in project {project_id}",
+    )
+    if not result:
+        raise ValueError(f"Wiki page with slug '{slug}' not found in project {project_id}")
+    return _filter_response(result, "wiki_page", verbosity)
+
+
+@mcp.tool(
+    "update_wiki_page",
+    description="Updates an existing wiki page. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+)
+def update_wiki_page(
+    wiki_page_id: int,
+    kwargs: Any = None,
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
+) -> Dict[str, Any]:
+    """Updates a wiki page. Pass fields to update as kwargs JSON string (e.g., {"content": "New content", "slug": "new-slug"})."""
+    actual_session_id = _get_session_id(session_id)
+    parsed_kwargs = _validate_kwargs("wiki_page", _parse_mcp_kwargs({"kwargs": kwargs}))
+    logger.info(
+        f"Executing update_wiki_page ID {wiki_page_id} for session {actual_session_id[:8]} with data: {parsed_kwargs}"
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+    try:
+        if not parsed_kwargs:
+            logger.info(f"No fields provided for update on wiki page {wiki_page_id}")
+            result = taiga_client_wrapper.api.wiki.get(wiki_page_id)
+            return _filter_response(result, "wiki_page", verbosity)
+
+        # Get current wiki page data to retrieve version
+        current_page = taiga_client_wrapper.api.wiki.get(wiki_page_id)
+        version = current_page.get("version")
+        if not version:
+            raise ValueError(f"Could not determine version for wiki page {wiki_page_id}")
+
+        # Use edit method for partial updates
+        updated_page = taiga_client_wrapper.api.wiki.edit(
+            wiki_page_id=wiki_page_id, version=version, data=parsed_kwargs
+        )
+        logger.info(f"Wiki page {wiki_page_id} update request sent.")
+        return _filter_response(updated_page, "wiki_page", verbosity)
+    except TaigaException as e:
+        logger.error(f"Taiga API error updating wiki page {wiki_page_id}: {e}", exc_info=False)
+        raise e
+    except Exception as e:
+        logger.error(f"Unexpected error updating wiki page {wiki_page_id}: {e}", exc_info=True)
+        raise RuntimeError(f"Server error updating wiki page: {e}")
+
+
+@mcp.tool(
+    "delete_wiki_page",
+    description="Deletes a wiki page by its ID. Uses default session if session_id not provided.",
+)
+def delete_wiki_page(wiki_page_id: int, session_id: Optional[str] = None) -> Dict[str, Any]:
+    """Deletes a wiki page by ID."""
+    actual_session_id = _get_session_id(session_id)
+    logger.warning(
+        f"Executing delete_wiki_page ID {wiki_page_id} for session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_delete():
+        taiga_client_wrapper.api.wiki.delete(wiki_page_id=wiki_page_id)
+        return {"status": "deleted", "wiki_page_id": wiki_page_id}
+
+    return _execute_taiga_operation("delete_wiki_page", do_delete, f"wiki page {wiki_page_id}")
+
+
 # --- Session Management Tools ---
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -826,6 +826,135 @@ def delete_project(project_id: int, session_id: Optional[str] = None) -> Dict[st
     return _execute_taiga_operation("delete_project", do_delete, f"project {project_id}")
 
 
+# --- Project Tag Management ---
+
+
+@mcp.tool()
+def get_project_tags_colors(
+    project_id: int,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get the tag-color mapping for a project.
+
+    Args:
+        project_id: The project ID
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict mapping tag names to hex color strings (e.g., {'bug': '#FF0000'}).
+    """
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing get_project_tags_colors for project {project_id} "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_get():
+        return taiga_client_wrapper.api.get(f"/projects/{project_id}/tags_colors")
+
+    return _execute_taiga_operation("get_project_tags_colors", do_get, f"project {project_id}")
+
+
+@mcp.tool()
+def edit_project_tag(
+    project_id: int,
+    tag: str,
+    color: Optional[str] = None,
+    new_tag: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Rename or recolor a tag in a project.
+
+    Args:
+        project_id: The project ID
+        tag: The current tag name to edit
+        color: New hex color for the tag (e.g., '#FF0000'). Pass None to keep current color.
+        new_tag: New name for the tag. Pass None to keep current name.
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict confirming the operation with the updated tag details.
+    """
+    tag = tag.strip() if tag else ""
+    if not tag:
+        raise ValueError("Tag name cannot be empty.")
+    new_tag = new_tag.strip() if new_tag else None
+    if color is None and new_tag is None:
+        raise ValueError("At least one of 'color' or 'new_tag' must be provided.")
+
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing edit_project_tag '{tag}' in project {project_id} "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_edit():
+        payload = {"tag": tag}
+        if color is not None:
+            payload["color"] = color
+        if new_tag is not None:
+            payload["new_tag"] = new_tag
+        taiga_client_wrapper.api.post(f"/projects/{project_id}/edit_tag", json=payload)
+        return {
+            "status": "tag_updated",
+            "project_id": project_id,
+            "tag": tag,
+            "color": color,
+            "new_tag": new_tag,
+        }
+
+    return _execute_taiga_operation("edit_project_tag", do_edit, f"project {project_id}")
+
+
+@mcp.tool()
+def mix_project_tags(
+    project_id: int,
+    from_tags: List[str],
+    to_tag: str,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Merge multiple tags into a single tag in a project.
+
+    All items tagged with any of the 'from_tags' will be retagged with 'to_tag'.
+    The original tags are removed.
+
+    Args:
+        project_id: The project ID
+        from_tags: List of tag names to merge from
+        to_tag: The target tag name to merge into
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict confirming the merge operation.
+    """
+    to_tag = to_tag.strip() if to_tag else ""
+    if not to_tag:
+        raise ValueError("Target tag name ('to_tag') cannot be empty.")
+    if not from_tags or not any(t.strip() for t in from_tags):
+        raise ValueError("'from_tags' must contain at least one non-empty tag name.")
+
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing mix_project_tags in project {project_id} session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_mix():
+        cleaned_from = [t.strip() for t in from_tags if t.strip()]
+        payload = {"from_tags": cleaned_from, "to_tag": to_tag}
+        taiga_client_wrapper.api.post(f"/projects/{project_id}/mix_tags", json=payload)
+        return {
+            "status": "tags_merged",
+            "project_id": project_id,
+            "from_tags": cleaned_from,
+            "to_tag": to_tag,
+        }
+
+    return _execute_taiga_operation("mix_project_tags", do_mix, f"project {project_id}")
+
+
 # --- User Story Tools ---
 # Note: get_project_roles not implemented - not supported by pytaigaclient
 

--- a/src/server.py
+++ b/src/server.py
@@ -2780,6 +2780,325 @@ def get_history(
     return _execute_taiga_operation("get_history", do_get_history, f"{object_type} {object_id}")
 
 
+# --- Bulk Operations ---
+
+
+@mcp.tool(
+    "bulk_create_user_stories",
+    description="Creates multiple user stories at once from a list of subjects. All stories are created in the specified project. Returns the list of created stories. Uses default session if session_id not provided.",
+)
+def bulk_create_user_stories(
+    project_id: int,
+    subjects: List[str],
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
+) -> List[Dict[str, Any]]:
+    """Bulk-creates user stories from a list of subject strings."""
+    actual_session_id = _get_session_id(session_id)
+    if not subjects:
+        raise ValueError("Subjects list cannot be empty.")
+    cleaned = [s.strip() for s in subjects if s and s.strip()]
+    if not cleaned:
+        raise ValueError("Subjects list contains only empty strings.")
+    logger.info(
+        f"Executing bulk_create_user_stories: {len(cleaned)} stories in project {project_id}, "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_bulk():
+        bulk_stories = "\n".join(cleaned)
+        result = taiga_client_wrapper.api.post(
+            "/userstories/bulk_create",
+            json={"project_id": project_id, "bulk_stories": bulk_stories},
+        )
+        return result if isinstance(result, list) else []
+
+    result = _execute_taiga_operation(
+        "bulk_create_user_stories", do_bulk, f"{len(cleaned)} stories in project {project_id}"
+    )
+    return _filter_response(result, "user_story", verbosity)
+
+
+@mcp.tool(
+    "bulk_create_tasks",
+    description="Creates multiple tasks at once from a list of subjects. All tasks are created in the specified project, optionally linked to a user story. Returns the list of created tasks. Uses default session if session_id not provided.",
+)
+def bulk_create_tasks(
+    project_id: int,
+    subjects: List[str],
+    user_story_id: Optional[int] = None,
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
+) -> List[Dict[str, Any]]:
+    """Bulk-creates tasks from a list of subject strings."""
+    actual_session_id = _get_session_id(session_id)
+    if not subjects:
+        raise ValueError("Subjects list cannot be empty.")
+    cleaned = [s.strip() for s in subjects if s and s.strip()]
+    if not cleaned:
+        raise ValueError("Subjects list contains only empty strings.")
+    logger.info(
+        f"Executing bulk_create_tasks: {len(cleaned)} tasks in project {project_id}, "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_bulk():
+        bulk_tasks = "\n".join(cleaned)
+        payload: Dict[str, Any] = {"project_id": project_id, "bulk_tasks": bulk_tasks}
+        if user_story_id is not None:
+            payload["us_id"] = user_story_id
+        result = taiga_client_wrapper.api.post("/tasks/bulk_create", json=payload)
+        return result if isinstance(result, list) else []
+
+    result = _execute_taiga_operation(
+        "bulk_create_tasks", do_bulk, f"{len(cleaned)} tasks in project {project_id}"
+    )
+    return _filter_response(result, "task", verbosity)
+
+
+@mcp.tool(
+    "bulk_create_issues",
+    description="Creates multiple issues at once from a list of subjects. All issues are created in the specified project. Returns the list of created issues. Uses default session if session_id not provided.",
+)
+def bulk_create_issues(
+    project_id: int,
+    subjects: List[str],
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
+) -> List[Dict[str, Any]]:
+    """Bulk-creates issues from a list of subject strings."""
+    actual_session_id = _get_session_id(session_id)
+    if not subjects:
+        raise ValueError("Subjects list cannot be empty.")
+    cleaned = [s.strip() for s in subjects if s and s.strip()]
+    if not cleaned:
+        raise ValueError("Subjects list contains only empty strings.")
+    logger.info(
+        f"Executing bulk_create_issues: {len(cleaned)} issues in project {project_id}, "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_bulk():
+        bulk_issues = "\n".join(cleaned)
+        result = taiga_client_wrapper.api.post(
+            "/issues/bulk_create",
+            json={"project_id": project_id, "bulk_issues": bulk_issues},
+        )
+        return result if isinstance(result, list) else []
+
+    result = _execute_taiga_operation(
+        "bulk_create_issues", do_bulk, f"{len(cleaned)} issues in project {project_id}"
+    )
+    return _filter_response(result, "issue", verbosity)
+
+
+@mcp.tool(
+    "bulk_create_epics",
+    description="Creates multiple epics at once from a list of subjects. All epics are created in the specified project. Returns the list of created epics. Uses default session if session_id not provided.",
+)
+def bulk_create_epics(
+    project_id: int,
+    subjects: List[str],
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
+) -> List[Dict[str, Any]]:
+    """Bulk-creates epics from a list of subject strings."""
+    actual_session_id = _get_session_id(session_id)
+    if not subjects:
+        raise ValueError("Subjects list cannot be empty.")
+    cleaned = [s.strip() for s in subjects if s and s.strip()]
+    if not cleaned:
+        raise ValueError("Subjects list contains only empty strings.")
+    logger.info(
+        f"Executing bulk_create_epics: {len(cleaned)} epics in project {project_id}, "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_bulk():
+        bulk_epics = "\n".join(cleaned)
+        result = taiga_client_wrapper.api.post(
+            "/epics/bulk_create",
+            json={"project_id": project_id, "bulk_epics": bulk_epics},
+        )
+        return result if isinstance(result, list) else []
+
+    result = _execute_taiga_operation(
+        "bulk_create_epics", do_bulk, f"{len(cleaned)} epics in project {project_id}"
+    )
+    return _filter_response(result, "epic", verbosity)
+
+
+@mcp.tool(
+    "bulk_update_user_story_milestone",
+    description="Moves multiple user stories to a sprint (milestone) in a single call. Requires project_id, milestone_id, and a list of user story IDs (bulk_stories). Uses default session if session_id not provided.",
+)
+def bulk_update_user_story_milestone(
+    project_id: int,
+    milestone_id: int,
+    bulk_stories: List[Dict[str, int]],
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Moves multiple user stories to a milestone. bulk_stories is a list of {us_id, order} dicts."""
+    actual_session_id = _get_session_id(session_id)
+    if not bulk_stories:
+        raise ValueError("bulk_stories list cannot be empty.")
+    logger.info(
+        f"Executing bulk_update_user_story_milestone: {len(bulk_stories)} stories -> "
+        f"milestone {milestone_id} in project {project_id}, session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_bulk():
+        taiga_client_wrapper.api.post(
+            "/userstories/bulk_update_milestone",
+            json={
+                "project_id": project_id,
+                "milestone_id": milestone_id,
+                "bulk_stories": bulk_stories,
+            },
+        )
+        return {
+            "status": "updated",
+            "project_id": project_id,
+            "milestone_id": milestone_id,
+            "stories_moved": len(bulk_stories),
+        }
+
+    return _execute_taiga_operation(
+        "bulk_update_user_story_milestone",
+        do_bulk,
+        f"{len(bulk_stories)} stories to milestone {milestone_id}",
+    )
+
+
+@mcp.tool(
+    "bulk_update_user_story_order",
+    description="Reorders multiple user stories in bulk. order_type must be 'backlog', 'kanban', or 'sprint'. bulk_stories is a list of {us_id, order} dicts. Uses default session if session_id not provided.",
+)
+def bulk_update_user_story_order(
+    project_id: int,
+    order_type: str,
+    bulk_stories: List[Dict[str, int]],
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Reorders user stories in bulk for a given view (backlog, kanban, or sprint)."""
+    actual_session_id = _get_session_id(session_id)
+    valid_order_types = {"backlog", "kanban", "sprint"}
+    order_type = order_type.strip().lower()
+    if order_type not in valid_order_types:
+        raise ValueError(
+            f"Invalid order_type '{order_type}'. Must be one of: {sorted(valid_order_types)}"
+        )
+    if not bulk_stories:
+        raise ValueError("bulk_stories list cannot be empty.")
+    logger.info(
+        f"Executing bulk_update_user_story_order: {len(bulk_stories)} stories, "
+        f"order_type={order_type} in project {project_id}, session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_bulk():
+        endpoint = f"/userstories/bulk_update_{order_type}_order"
+        taiga_client_wrapper.api.post(
+            endpoint,
+            json={"project_id": project_id, "bulk_stories": bulk_stories},
+        )
+        return {
+            "status": "reordered",
+            "project_id": project_id,
+            "order_type": order_type,
+            "stories_reordered": len(bulk_stories),
+        }
+
+    return _execute_taiga_operation(
+        "bulk_update_user_story_order",
+        do_bulk,
+        f"{len(bulk_stories)} stories ({order_type}) in project {project_id}",
+    )
+
+
+@mcp.tool(
+    "bulk_create_memberships",
+    description="Invites multiple users to a project at once. Each invitation needs an email and role_id. Uses default session if session_id not provided.",
+)
+def bulk_create_memberships(
+    project_id: int,
+    members: List[Dict[str, Any]],
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Bulk-invites members to a project. members is a list of {role_id, email} dicts."""
+    actual_session_id = _get_session_id(session_id)
+    if not members:
+        raise ValueError("Members list cannot be empty.")
+    for m in members:
+        if not m.get("email") or not m.get("role_id"):
+            raise ValueError("Each member must have 'email' and 'role_id' fields.")
+    logger.info(
+        f"Executing bulk_create_memberships: {len(members)} members in project {project_id}, "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_bulk():
+        result = taiga_client_wrapper.api.post(
+            "/memberships/bulk_create",
+            json={"project_id": project_id, "bulk_memberships": members},
+        )
+        if isinstance(result, list):
+            return {"status": "invited", "project_id": project_id, "members_invited": result}
+        return {
+            "status": "invited",
+            "project_id": project_id,
+            "members_count": len(members),
+        }
+
+    return _execute_taiga_operation(
+        "bulk_create_memberships", do_bulk, f"{len(members)} members in project {project_id}"
+    )
+
+
+@mcp.tool(
+    "bulk_link_user_stories_to_epic",
+    description="Links multiple user stories to an epic in a single call. Uses default session if session_id not provided.",
+)
+def bulk_link_user_stories_to_epic(
+    epic_id: int,
+    user_story_ids: List[int],
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Links multiple user stories to an epic at once."""
+    actual_session_id = _get_session_id(session_id)
+    if not user_story_ids:
+        raise ValueError("user_story_ids list cannot be empty.")
+    logger.info(
+        f"Executing bulk_link_user_stories_to_epic: {len(user_story_ids)} stories -> "
+        f"epic {epic_id}, session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_bulk():
+        taiga_client_wrapper.api.post(
+            f"/epics/{epic_id}/related_userstories/bulk_create",
+            json={"project_id": epic_id, "bulk_userstories": user_story_ids},
+        )
+        return {
+            "status": "linked",
+            "epic_id": epic_id,
+            "user_story_ids": user_story_ids,
+            "count": len(user_story_ids),
+        }
+
+    return _execute_taiga_operation(
+        "bulk_link_user_stories_to_epic",
+        do_bulk,
+        f"{len(user_story_ids)} stories to epic {epic_id}",
+    )
+
+
 # --- Search ---
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -397,12 +397,21 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
 
 
 # --- MCP Server Definition ---
+_mcp_port_str = os.environ.get("MCP_PORT", "8000")
+try:
+    _mcp_port = int(_mcp_port_str)
+except ValueError:
+    logger.error(
+        f"Invalid MCP_PORT value '{_mcp_port_str}', must be a number. Falling back to 8000."
+    )
+    _mcp_port = 8000
+
 mcp = FastMCP(
     "Taiga Bridge",
     dependencies=["pytaigaclient"],
     lifespan=server_lifespan,
     host=os.environ.get("MCP_HOST", "127.0.0.1"),
-    port=int(os.environ.get("MCP_PORT", "8000")),
+    port=_mcp_port,
 )
 
 # --- Helper Functions for Session Validation ---

--- a/src/server.py
+++ b/src/server.py
@@ -650,7 +650,7 @@ def list_projects(
     logger.info(f"Executing list_projects for session {actual_session_id[:8]}...")
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
     result = _execute_taiga_operation(
-        "list_projects", lambda: taiga_client_wrapper.api.projects.list()
+        "list_projects", lambda: taiga_client_wrapper.list_resources("projects")
     )
     return _filter_response(result, "project", verbosity)
 
@@ -833,7 +833,9 @@ def list_user_stories(
 
     result = _execute_taiga_operation(
         "list_user_stories",
-        lambda: taiga_client_wrapper.api.user_stories.list(project=project_id, **parsed_filters),
+        lambda: taiga_client_wrapper.list_resources(
+            "user_stories", project_id=project_id, **parsed_filters
+        ),
         f"project {project_id}",
     )
     return _filter_response(result, "user_story", verbosity)
@@ -1015,9 +1017,7 @@ def get_user_story_statuses(
 
     return _execute_taiga_operation(
         "get_user_story_statuses",
-        lambda: taiga_client_wrapper.api.userstory_statuses.list(
-            query_params={"project": project_id}
-        ),
+        lambda: taiga_client_wrapper.list_resources("userstory_statuses", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1043,13 +1043,11 @@ def list_tasks(
     )
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
 
-    # Workaround: pytaigaclient Tasks.list has a bug - passes query_params but TaigaClient.get expects params
-    # Use the underlying get method directly
-    query = {"project": project_id, **parsed_filters}
-
     result = _execute_taiga_operation(
         "list_tasks",
-        lambda: taiga_client_wrapper.api.get("/tasks", params=query),
+        lambda: taiga_client_wrapper.list_resources(
+            "tasks", project_id=project_id, **parsed_filters
+        ),
         f"project {project_id}",
     )
     return _filter_response(result, "task", verbosity)
@@ -1234,7 +1232,7 @@ def get_task_statuses(project_id: int, session_id: Optional[str] = None) -> List
 
     return _execute_taiga_operation(
         "get_task_statuses",
-        lambda: taiga_client_wrapper.api.task_statuses.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("task_statuses", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1260,11 +1258,11 @@ def list_issues(
     )
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
 
-    query = {"project": project_id, **parsed_filters}
-
     result = _execute_taiga_operation(
         "list_issues",
-        lambda: taiga_client_wrapper.api.issues.list(query_params=query),
+        lambda: taiga_client_wrapper.list_resources(
+            "issues", project_id=project_id, **parsed_filters
+        ),
         f"project {project_id}",
     )
     return _filter_response(result, "issue", verbosity)
@@ -1446,7 +1444,7 @@ def get_issue_statuses(project_id: int, session_id: Optional[str] = None) -> Lis
 
     return _execute_taiga_operation(
         "get_issue_statuses",
-        lambda: taiga_client_wrapper.api.issue_statuses.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("issue_statuses", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1465,7 +1463,7 @@ def get_issue_priorities(project_id: int, session_id: Optional[str] = None) -> L
 
     return _execute_taiga_operation(
         "get_issue_priorities",
-        lambda: taiga_client_wrapper.api.get("/priorities", params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("priorities", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1484,7 +1482,7 @@ def get_issue_severities(project_id: int, session_id: Optional[str] = None) -> L
 
     return _execute_taiga_operation(
         "get_issue_severities",
-        lambda: taiga_client_wrapper.api.get("/severities", params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("severities", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1503,7 +1501,7 @@ def get_issue_types(project_id: int, session_id: Optional[str] = None) -> List[D
 
     return _execute_taiga_operation(
         "get_issue_types",
-        lambda: taiga_client_wrapper.api.issue_types.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("issue_types", project_id=project_id),
         f"project {project_id}",
     )
 
@@ -1529,11 +1527,11 @@ def list_epics(
     )
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
 
-    query = {"project": project_id, **parsed_filters}
-
     result = _execute_taiga_operation(
         "list_epics",
-        lambda: taiga_client_wrapper.api.epics.list(query_params=query),
+        lambda: taiga_client_wrapper.list_resources(
+            "epics", project_id=project_id, **parsed_filters
+        ),
         f"project {project_id}",
     )
     return _filter_response(result, "epic", verbosity)
@@ -1739,7 +1737,7 @@ def list_milestones(
 
     result = _execute_taiga_operation(
         "list_milestones",
-        lambda: taiga_client_wrapper.api.milestones.list(project=project_id),
+        lambda: taiga_client_wrapper.list_resources("milestones", project_id=project_id),
         f"project {project_id}",
     )
     return _filter_response(result, "milestone", verbosity)
@@ -1882,7 +1880,7 @@ def get_project_members(
 
     result = _execute_taiga_operation(
         "get_project_members",
-        lambda: taiga_client_wrapper.api.memberships.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("memberships", project_id=project_id),
         f"project {project_id}",
     )
     return _filter_response(result, "member", verbosity)
@@ -1938,7 +1936,7 @@ def list_wiki_pages(
 
     result = _execute_taiga_operation(
         "list_wiki_pages",
-        lambda: taiga_client_wrapper.api.wiki.list(query_params={"project": project_id}),
+        lambda: taiga_client_wrapper.list_resources("wiki", project_id=project_id),
         f"project {project_id}",
     )
     return _filter_response(result, "wiki_page", verbosity)

--- a/src/server.py
+++ b/src/server.py
@@ -2394,6 +2394,200 @@ def list_comments(
     return _execute_taiga_operation("list_comments", do_list_comments, f"{object_type} {object_id}")
 
 
+@mcp.tool()
+def edit_comment(
+    object_id: int,
+    object_type: str,
+    comment_id: str,
+    new_comment: str,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Edit an existing comment on a Taiga object.
+
+    Args:
+        object_id: The ID of the object the comment belongs to
+        object_type: Type of object: 'issue', 'task', 'user_story', 'userstory', or 'epic'
+        comment_id: The ID of the comment to edit
+        new_comment: The new comment text
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict confirming the edit operation.
+    """
+    if object_type not in _COMMENT_TYPE_MAP:
+        raise ValueError(
+            f"Invalid object_type '{object_type}'. "
+            f"Must be one of: {', '.join(sorted(_COMMENT_TYPE_MAP.keys()))}"
+        )
+    new_comment = new_comment.strip() if new_comment else ""
+    if not new_comment:
+        raise ValueError("New comment text must not be empty.")
+    if not comment_id or not comment_id.strip():
+        raise ValueError("Comment ID must not be empty.")
+
+    _, history_path = _COMMENT_TYPE_MAP[object_type]
+    actual_session_id = _get_session_id(session_id)
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_edit():
+        taiga_client_wrapper.api.post(
+            f"/history/{history_path}/{object_id}/edit_comment",
+            json={"comment_id": comment_id, "comment": new_comment},
+        )
+        return {
+            "status": "comment_edited",
+            "object_type": object_type,
+            "object_id": object_id,
+            "comment_id": comment_id,
+        }
+
+    return _execute_taiga_operation(
+        "edit_comment", do_edit, f"{object_type} {object_id} comment {comment_id}"
+    )
+
+
+@mcp.tool()
+def delete_comment(
+    object_id: int,
+    object_type: str,
+    comment_id: str,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Soft-delete a comment on a Taiga object. Can be restored with undelete_comment.
+
+    Args:
+        object_id: The ID of the object the comment belongs to
+        object_type: Type of object: 'issue', 'task', 'user_story', 'userstory', or 'epic'
+        comment_id: The ID of the comment to delete
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict confirming the delete operation.
+    """
+    if object_type not in _COMMENT_TYPE_MAP:
+        raise ValueError(
+            f"Invalid object_type '{object_type}'. "
+            f"Must be one of: {', '.join(sorted(_COMMENT_TYPE_MAP.keys()))}"
+        )
+    if not comment_id or not comment_id.strip():
+        raise ValueError("Comment ID must not be empty.")
+
+    _, history_path = _COMMENT_TYPE_MAP[object_type]
+    actual_session_id = _get_session_id(session_id)
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_delete():
+        taiga_client_wrapper.api.post(
+            f"/history/{history_path}/{object_id}/delete_comment",
+            json={"comment_id": comment_id},
+        )
+        return {
+            "status": "comment_deleted",
+            "object_type": object_type,
+            "object_id": object_id,
+            "comment_id": comment_id,
+        }
+
+    return _execute_taiga_operation(
+        "delete_comment", do_delete, f"{object_type} {object_id} comment {comment_id}"
+    )
+
+
+@mcp.tool()
+def undelete_comment(
+    object_id: int,
+    object_type: str,
+    comment_id: str,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Restore a previously soft-deleted comment on a Taiga object.
+
+    Args:
+        object_id: The ID of the object the comment belongs to
+        object_type: Type of object: 'issue', 'task', 'user_story', 'userstory', or 'epic'
+        comment_id: The ID of the comment to restore
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict confirming the restore operation.
+    """
+    if object_type not in _COMMENT_TYPE_MAP:
+        raise ValueError(
+            f"Invalid object_type '{object_type}'. "
+            f"Must be one of: {', '.join(sorted(_COMMENT_TYPE_MAP.keys()))}"
+        )
+    if not comment_id or not comment_id.strip():
+        raise ValueError("Comment ID must not be empty.")
+
+    _, history_path = _COMMENT_TYPE_MAP[object_type]
+    actual_session_id = _get_session_id(session_id)
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_undelete():
+        taiga_client_wrapper.api.post(
+            f"/history/{history_path}/{object_id}/undelete_comment",
+            json={"comment_id": comment_id},
+        )
+        return {
+            "status": "comment_restored",
+            "object_type": object_type,
+            "object_id": object_id,
+            "comment_id": comment_id,
+        }
+
+    return _execute_taiga_operation(
+        "undelete_comment", do_undelete, f"{object_type} {object_id} comment {comment_id}"
+    )
+
+
+@mcp.tool()
+def get_comment_versions(
+    object_id: int,
+    object_type: str,
+    comment_id: str,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get the edit history (versions) of a comment on a Taiga object.
+
+    Args:
+        object_id: The ID of the object the comment belongs to
+        object_type: Type of object: 'issue', 'task', 'user_story', 'userstory', or 'epic'
+        comment_id: The ID of the comment
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict with 'comment_id' and 'versions' list containing past versions of the comment.
+    """
+    if object_type not in _COMMENT_TYPE_MAP:
+        raise ValueError(
+            f"Invalid object_type '{object_type}'. "
+            f"Must be one of: {', '.join(sorted(_COMMENT_TYPE_MAP.keys()))}"
+        )
+    if not comment_id or not comment_id.strip():
+        raise ValueError("Comment ID must not be empty.")
+
+    _, history_path = _COMMENT_TYPE_MAP[object_type]
+    actual_session_id = _get_session_id(session_id)
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_get_versions():
+        result = taiga_client_wrapper.api.get(
+            f"/history/{history_path}/{object_id}/comment_versions/{comment_id}"
+        )
+        return {
+            "object_type": object_type,
+            "object_id": object_id,
+            "comment_id": comment_id,
+            "versions": result,
+        }
+
+    return _execute_taiga_operation(
+        "get_comment_versions",
+        do_get_versions,
+        f"{object_type} {object_id} comment {comment_id}",
+    )
+
+
 # --- Search ---
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -2,6 +2,8 @@
 import json
 import logging
 import logging.config
+import os
+import sys
 import uuid
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, List, Optional
@@ -2162,6 +2164,45 @@ def list_comments(
     return _execute_taiga_operation("list_comments", do_list_comments, f"{object_type} {object_id}")
 
 
+VALID_TRANSPORTS = ("stdio", "sse", "streamable-http")
+
+
+def _resolve_transport(argv: list[str] | None = None, env: dict[str, str] | None = None) -> str:
+    """Determine the MCP transport from CLI flags or environment variable.
+
+    Priority: CLI flags (--sse, --streamable-http) > TAIGA_TRANSPORT env var > default (stdio).
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv).
+        env: Environment variables (defaults to os.environ).
+
+    Returns:
+        The transport name to use.
+    """
+    if argv is None:
+        argv = sys.argv
+    if env is None:
+        env = dict(os.environ)
+
+    if "--sse" in argv:
+        return "sse"
+    if "--streamable-http" in argv:
+        return "streamable-http"
+
+    env_transport = env.get("TAIGA_TRANSPORT", "").lower()
+    if env_transport in VALID_TRANSPORTS:
+        return env_transport
+    if env_transport:
+        logger.warning(
+            f"Unknown TAIGA_TRANSPORT value '{env_transport}', falling back to stdio. "
+            f"Valid values: {', '.join(VALID_TRANSPORTS)}"
+        )
+
+    return "stdio"
+
+
 # --- Run the server ---
 if __name__ == "__main__":
-    mcp.run()
+    transport = _resolve_transport()
+    logger.info(f"Starting server with {transport} transport")
+    mcp.run(transport=transport)

--- a/src/server.py
+++ b/src/server.py
@@ -1664,6 +1664,139 @@ def get_issue_types(project_id: int, session_id: Optional[str] = None) -> List[D
     )
 
 
+# --- Story Points Tools ---
+
+
+@mcp.tool()
+def list_points(
+    project_id: int,
+    session_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """List the story point values defined for a project.
+
+    Args:
+        project_id: The project ID
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        List of point dicts with id, name, value, and order.
+    """
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing list_points for project {project_id} session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    return _execute_taiga_operation(
+        "list_points",
+        lambda: taiga_client_wrapper.list_resources("points", project_id=project_id),
+        f"project {project_id}",
+    )
+
+
+@mcp.tool()
+def create_point(
+    project_id: int,
+    name: str,
+    value: Optional[float] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a new story point value for a project.
+
+    Args:
+        project_id: The project ID
+        name: The name/label for the point value (e.g., '1', '2', '3', '5', '8', '?')
+        value: Optional numeric value for ordering/calculation. None for non-numeric points.
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict with the created point details.
+    """
+    name = name.strip() if name else ""
+    if not name:
+        raise ValueError("Point name cannot be empty.")
+
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing create_point '{name}' in project {project_id} "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_create():
+        payload: Dict[str, Any] = {"project": project_id, "name": name}
+        if value is not None:
+            payload["value"] = value
+        return taiga_client_wrapper.api.post("/points", json=payload)
+
+    return _execute_taiga_operation("create_point", do_create, f"project {project_id}")
+
+
+@mcp.tool()
+def update_point(
+    point_id: int,
+    name: Optional[str] = None,
+    value: Optional[float] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Update an existing story point value.
+
+    Args:
+        point_id: The ID of the point to update
+        name: New name for the point value
+        value: New numeric value
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict with the updated point details.
+    """
+    if name is not None:
+        name = name.strip()
+        if not name:
+            raise ValueError("Point name cannot be empty.")
+    if name is None and value is None:
+        raise ValueError("At least one of 'name' or 'value' must be provided.")
+
+    actual_session_id = _get_session_id(session_id)
+    logger.info(f"Executing update_point {point_id} session {actual_session_id[:8]}...")
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_update():
+        payload: Dict[str, Any] = {}
+        if name is not None:
+            payload["name"] = name
+        if value is not None:
+            payload["value"] = value
+        return taiga_client_wrapper.api.patch(f"/points/{point_id}", json=payload)
+
+    return _execute_taiga_operation("update_point", do_update, f"point {point_id}")
+
+
+@mcp.tool()
+def delete_point(
+    point_id: int,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Delete a story point value.
+
+    Args:
+        point_id: The ID of the point to delete
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict confirming the delete operation.
+    """
+    actual_session_id = _get_session_id(session_id)
+    logger.warning(f"Executing delete_point {point_id} session {actual_session_id[:8]}...")
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_delete():
+        taiga_client_wrapper.api.delete(f"/points/{point_id}")
+        return {"status": "deleted", "point_id": point_id}
+
+    return _execute_taiga_operation("delete_point", do_delete, f"point {point_id}")
+
+
 # --- Epic Tools ---
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -397,7 +397,13 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
 
 
 # --- MCP Server Definition ---
-mcp = FastMCP("Taiga Bridge", dependencies=["pytaigaclient"], lifespan=server_lifespan)
+mcp = FastMCP(
+    "Taiga Bridge",
+    dependencies=["pytaigaclient"],
+    lifespan=server_lifespan,
+    host=os.environ.get("MCP_HOST", "127.0.0.1"),
+    port=int(os.environ.get("MCP_PORT", "8000")),
+)
 
 # --- Helper Functions for Session Validation ---
 

--- a/src/server.py
+++ b/src/server.py
@@ -2265,6 +2265,54 @@ def list_comments(
     return _execute_taiga_operation("list_comments", do_list_comments, f"{object_type} {object_id}")
 
 
+# --- Search ---
+
+
+@mcp.tool()
+def search_project(
+    project_id: int,
+    text: str,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Search across a Taiga project for user stories, tasks, issues, wiki pages, and epics.
+
+    Uses Taiga's built-in search endpoint to find items matching the given text query.
+
+    Args:
+        project_id: The project ID to search within
+        text: The search query text
+        session_id: Optional session ID (uses default if not provided)
+
+    Returns:
+        Dict with keys 'count' (total matches) and 'userstories', 'tasks', 'issues',
+        'wikipages', 'epics' — each a list of matching items with core fields.
+    """
+    text = text.strip() if text else ""
+    if not text:
+        raise ValueError("Search text cannot be empty.")
+
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing search_project in project {project_id} for session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_search():
+        result = taiga_client_wrapper.api.get(
+            "/search", params={"project": project_id, "text": text}
+        )
+        return {
+            "count": result.get("count", 0),
+            "userstories": result.get("userstories", []),
+            "tasks": result.get("tasks", []),
+            "issues": result.get("issues", []),
+            "wikipages": result.get("wikipages", []),
+            "epics": result.get("epics", []),
+        }
+
+    return _execute_taiga_operation("search_project", do_search, f"project {project_id}")
+
+
 VALID_TRANSPORTS = ("stdio", "sse", "streamable-http")
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -397,7 +397,22 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
 
 
 # --- MCP Server Definition ---
-mcp = FastMCP("Taiga Bridge", dependencies=["pytaigaclient"], lifespan=server_lifespan)
+_mcp_port_str = os.environ.get("MCP_PORT", "8000")
+try:
+    _mcp_port = int(_mcp_port_str)
+except ValueError:
+    logger.error(
+        f"Invalid MCP_PORT value '{_mcp_port_str}', must be a number. Falling back to 8000."
+    )
+    _mcp_port = 8000
+
+mcp = FastMCP(
+    "Taiga Bridge",
+    dependencies=["pytaigaclient"],
+    lifespan=server_lifespan,
+    host=os.environ.get("MCP_HOST", "127.0.0.1"),
+    port=_mcp_port,
+)
 
 # --- Helper Functions for Session Validation ---
 

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -7,13 +7,25 @@ from pytaigaclient.exceptions import TaigaException
 
 logger = logging.getLogger(__name__)
 
-# Resources that use the `project=X` keyword argument pattern
-_PROJECT_KWARG_RESOURCES = {"user_stories", "milestones"}
+# Endpoint mapping for all listable resources
+_RESOURCE_ENDPOINTS = {
+    "projects": "/projects",
+    "user_stories": "/userstories",
+    "tasks": "/tasks",
+    "issues": "/issues",
+    "epics": "/epics",
+    "milestones": "/milestones",
+    "wiki": "/wiki",
+    "memberships": "/memberships",
+    "userstory_statuses": "/userstory-statuses",
+    "task_statuses": "/task-statuses",
+    "issue_statuses": "/issue-statuses",
+    "issue_types": "/issue-types",
+    "priorities": "/priorities",
+    "severities": "/severities",
+}
 
-# Resources that require raw API calls due to pytaigaclient bugs
-_RAW_API_RESOURCES = {"tasks"}
-
-# All other resources use query_params={"project": X} pattern
+_NO_PAGINATION_HEADERS = {"x-disable-pagination": "True"}
 
 
 class TaigaClientWrapper:
@@ -80,7 +92,10 @@ class TaigaClientWrapper:
         self, resource_type: str, project_id: Optional[int] = None, **filters
     ) -> List[Dict[str, Any]]:
         """
-        Unified interface for listing resources, hiding pytaigaclient inconsistencies.
+        Unified interface for listing resources via raw API with pagination disabled.
+
+        Uses the x-disable-pagination header to bypass Taiga's default PAGE_SIZE=30
+        limit, ensuring all results are returned in a single request.
 
         Args:
             resource_type: The type of resource (e.g., 'user_stories', 'tasks', 'issues')
@@ -89,34 +104,16 @@ class TaigaClientWrapper:
 
         Returns:
             List of resource dictionaries
-
-        Note:
-            pytaigaclient has inconsistent APIs:
-            - user_stories, milestones use: list(project=X, **filters)
-            - tasks use raw API due to bug: api.get("/tasks", params={...})
-            - issues, epics, etc use: list(query_params={...})
         """
         self._ensure_authenticated()
-
-        if resource_type in _RAW_API_RESOURCES:
-            # Workaround: pytaigaclient Tasks.list passes query_params but
-            # TaigaClient.get expects params - use raw API call
-            # See: https://github.com/talhaorak/pyTaigaClient/issues/XXX
-            params = {"project": project_id, **filters} if project_id else filters
-            endpoint = f"/{resource_type}"
-            return self.api.get(endpoint, params=params)
-
-        resource = getattr(self.api, resource_type, None)
-        if resource is None:
-            raise ValueError(f"Unknown resource type: {resource_type}")
-
-        if resource_type in _PROJECT_KWARG_RESOURCES:
-            # These resources accept project as a keyword argument
-            if project_id:
-                return resource.list(project=project_id, **filters)
-            else:
-                return resource.list(**filters)
-        else:
-            # Default pattern: use query_params dict
-            query = {"project": project_id, **filters} if project_id else filters
-            return resource.list(query_params=query)
+        endpoint = _RESOURCE_ENDPOINTS.get(resource_type)
+        if endpoint is None:
+            raise ValueError(
+                f"Unknown resource type: {resource_type}. Valid: {sorted(_RESOURCE_ENDPOINTS)}"
+            )
+        params = {}
+        if project_id is not None:
+            params["project"] = project_id
+        params.update(filters)
+        result = self.api.get(endpoint, params=params, headers=_NO_PAGINATION_HEADERS)
+        return result if isinstance(result, list) else []

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -23,6 +23,7 @@ _RESOURCE_ENDPOINTS = {
     "issue_types": "/issue-types",
     "priorities": "/priorities",
     "severities": "/severities",
+    "points": "/points",
 }
 
 _NO_PAGINATION_HEADERS = {"x-disable-pagination": "True"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -330,6 +330,112 @@ class TestTaigaTools:
         assert result["project_id"] == 123
         mock_client.api.projects.delete.assert_called_once_with(project_id=123)
 
+    # ─── Project Tag Management tests ─────────────────────────────────
+
+    def test_get_project_tags_colors(self, session_setup):
+        """Test get_project_tags_colors returns tag-color mapping."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = {"bug": "#FF0000", "feature": "#00FF00"}
+
+        result = src.server.get_project_tags_colors(21, session_id)
+
+        mock_client.api.get.assert_called_once_with("/projects/21/tags_colors")
+        assert result == {"bug": "#FF0000", "feature": "#00FF00"}
+
+    def test_edit_project_tag_rename(self, session_setup):
+        """Test edit_project_tag renames a tag."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        result = src.server.edit_project_tag(
+            21, "old-name", new_tag="new-name", session_id=session_id
+        )
+
+        mock_client.api.post.assert_called_once_with(
+            "/projects/21/edit_tag", json={"tag": "old-name", "new_tag": "new-name"}
+        )
+        assert result["status"] == "tag_updated"
+        assert result["new_tag"] == "new-name"
+
+    def test_edit_project_tag_recolor(self, session_setup):
+        """Test edit_project_tag changes tag color."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        result = src.server.edit_project_tag(21, "bug", color="#FF0000", session_id=session_id)
+
+        mock_client.api.post.assert_called_once_with(
+            "/projects/21/edit_tag", json={"tag": "bug", "color": "#FF0000"}
+        )
+        assert result["status"] == "tag_updated"
+        assert result["color"] == "#FF0000"
+
+    def test_edit_project_tag_empty_name_raises(self, session_setup):
+        """Test edit_project_tag raises ValueError for empty tag name."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Tag name cannot be empty"):
+            src.server.edit_project_tag(21, "", color="#FF0000", session_id=session_id)
+
+    def test_edit_project_tag_rename_and_recolor(self, session_setup):
+        """Test edit_project_tag with both color and new_tag."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        result = src.server.edit_project_tag(
+            21, "bug", color="#0000FF", new_tag="defect", session_id=session_id
+        )
+
+        mock_client.api.post.assert_called_once_with(
+            "/projects/21/edit_tag",
+            json={"tag": "bug", "color": "#0000FF", "new_tag": "defect"},
+        )
+        assert result["status"] == "tag_updated"
+        assert result["color"] == "#0000FF"
+        assert result["new_tag"] == "defect"
+
+    def test_edit_project_tag_no_changes_raises(self, session_setup):
+        """Test edit_project_tag raises ValueError when neither color nor new_tag provided."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="At least one of"):
+            src.server.edit_project_tag(21, "bug", session_id=session_id)
+
+    def test_mix_project_tags(self, session_setup):
+        """Test mix_project_tags merges tags."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        result = src.server.mix_project_tags(21, ["bug", "defect"], "bug", session_id)
+
+        mock_client.api.post.assert_called_once_with(
+            "/projects/21/mix_tags", json={"from_tags": ["bug", "defect"], "to_tag": "bug"}
+        )
+        assert result["status"] == "tags_merged"
+        assert result["from_tags"] == ["bug", "defect"]
+        assert result["to_tag"] == "bug"
+
+    def test_mix_project_tags_empty_to_tag_raises(self, session_setup):
+        """Test mix_project_tags raises ValueError for empty target tag."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Target tag name"):
+            src.server.mix_project_tags(21, ["bug"], "", session_id)
+
+    def test_mix_project_tags_empty_from_tags_raises(self, session_setup):
+        """Test mix_project_tags raises ValueError for empty from_tags list."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="from_tags"):
+            src.server.mix_project_tags(21, [], "bug", session_id)
+
+    def test_mix_project_tags_strips_whitespace(self, session_setup):
+        """Test mix_project_tags strips whitespace from tag names."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        src.server.mix_project_tags(21, ["  bug  ", "defect", "  "], "  merged  ", session_id)
+
+        mock_client.api.post.assert_called_once_with(
+            "/projects/21/mix_tags", json={"from_tags": ["bug", "defect"], "to_tag": "merged"}
+        )
+
     # ─── User Story tools tests ──────────────────────────────────────
 
     def test_list_user_stories(self, session_setup):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1389,6 +1389,106 @@ class TestTaigaTools:
 
         assert result == []
 
+    # ─── Comment Management tests ──────────────────────────────────────
+
+    def test_edit_comment(self, session_setup):
+        """Test edit_comment posts to the correct history endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        result = src.server.edit_comment(42, "issue", "abc123", "Updated text", session_id)
+
+        mock_client.api.post.assert_called_once_with(
+            "/history/issue/42/edit_comment",
+            json={"comment_id": "abc123", "comment": "Updated text"},
+        )
+        assert result["status"] == "comment_edited"
+        assert result["comment_id"] == "abc123"
+
+    def test_edit_comment_strips_text(self, session_setup):
+        """Test edit_comment strips whitespace from new comment text."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        src.server.edit_comment(42, "task", "abc", "  trimmed  ", session_id)
+
+        mock_client.api.post.assert_called_once_with(
+            "/history/task/42/edit_comment",
+            json={"comment_id": "abc", "comment": "trimmed"},
+        )
+
+    def test_edit_comment_empty_text_raises(self, session_setup):
+        """Test edit_comment raises ValueError for empty new comment."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="New comment text must not be empty"):
+            src.server.edit_comment(42, "issue", "abc", "", session_id)
+
+    def test_edit_comment_invalid_type_raises(self, session_setup):
+        """Test edit_comment raises ValueError for invalid object_type."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Invalid object_type"):
+            src.server.edit_comment(42, "invalid", "abc", "text", session_id)
+
+    def test_delete_comment(self, session_setup):
+        """Test delete_comment posts to the correct history endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        result = src.server.delete_comment(42, "user_story", "abc123", session_id)
+
+        mock_client.api.post.assert_called_once_with(
+            "/history/userstory/42/delete_comment",
+            json={"comment_id": "abc123"},
+        )
+        assert result["status"] == "comment_deleted"
+        assert result["comment_id"] == "abc123"
+
+    def test_delete_comment_empty_id_raises(self, session_setup):
+        """Test delete_comment raises ValueError for empty comment_id."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Comment ID must not be empty"):
+            src.server.delete_comment(42, "issue", "", session_id)
+
+    def test_undelete_comment(self, session_setup):
+        """Test undelete_comment posts to the correct history endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        result = src.server.undelete_comment(42, "epic", "abc123", session_id)
+
+        mock_client.api.post.assert_called_once_with(
+            "/history/epic/42/undelete_comment",
+            json={"comment_id": "abc123"},
+        )
+        assert result["status"] == "comment_restored"
+        assert result["comment_id"] == "abc123"
+
+    def test_undelete_comment_invalid_type_raises(self, session_setup):
+        """Test undelete_comment raises ValueError for invalid object_type."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Invalid object_type"):
+            src.server.undelete_comment(42, "wiki", "abc", session_id)
+
+    def test_get_comment_versions(self, session_setup):
+        """Test get_comment_versions returns version history."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = [
+            {"date": "2026-01-01T00:00:00Z", "comment": "v1"},
+            {"date": "2026-01-02T00:00:00Z", "comment": "v2"},
+        ]
+
+        result = src.server.get_comment_versions(42, "task", "abc123", session_id)
+
+        mock_client.api.get.assert_called_once_with("/history/task/42/comment_versions/abc123")
+        assert result["comment_id"] == "abc123"
+        assert len(result["versions"]) == 2
+
+    def test_get_comment_versions_empty_id_raises(self, session_setup):
+        """Test get_comment_versions raises ValueError for empty comment_id."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Comment ID must not be empty"):
+            src.server.get_comment_versions(42, "issue", "", session_id)
+
     # ─── Login default session tests (PR: fix/login-default-session-and-slug) ──
 
     def test_login_sets_default_session_when_none_exists(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -911,6 +911,83 @@ class TestTaigaTools:
         assert len(result) == 2
         mock_client.list_resources.assert_called_once_with("issue_types", project_id=123)
 
+    # ─── Story Points tools tests ─────────────────────────────────────
+
+    def test_list_points(self, session_setup):
+        """Test list_points returns point values for a project."""
+        session_id, mock_client = session_setup
+        mock_client.list_resources.return_value = [
+            {"id": 1, "name": "1", "value": 1.0},
+            {"id": 2, "name": "3", "value": 3.0},
+        ]
+
+        result = src.server.list_points(21, session_id)
+
+        assert len(result) == 2
+        mock_client.list_resources.assert_called_once_with("points", project_id=21)
+
+    def test_create_point(self, session_setup):
+        """Test create_point creates a new point value."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {"id": 10, "name": "5", "value": 5.0}
+
+        result = src.server.create_point(21, "5", value=5.0, session_id=session_id)
+
+        mock_client.api.post.assert_called_once_with(
+            "/points", json={"project": 21, "name": "5", "value": 5.0}
+        )
+        assert result["name"] == "5"
+
+    def test_create_point_without_value(self, session_setup):
+        """Test create_point without numeric value (e.g., '?' point)."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {"id": 11, "name": "?"}
+
+        src.server.create_point(21, "?", session_id=session_id)
+
+        mock_client.api.post.assert_called_once_with("/points", json={"project": 21, "name": "?"})
+
+    def test_create_point_empty_name_raises(self, session_setup):
+        """Test create_point raises ValueError for empty name."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Point name cannot be empty"):
+            src.server.create_point(21, "", session_id=session_id)
+
+    def test_update_point(self, session_setup):
+        """Test update_point updates a point value."""
+        session_id, mock_client = session_setup
+        mock_client.api.patch.return_value = {"id": 10, "name": "8", "value": 8.0}
+
+        result = src.server.update_point(10, name="8", value=8.0, session_id=session_id)
+
+        mock_client.api.patch.assert_called_once_with(
+            "/points/10", json={"name": "8", "value": 8.0}
+        )
+        assert result["name"] == "8"
+
+    def test_update_point_no_changes_raises(self, session_setup):
+        """Test update_point raises ValueError when no fields provided."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="At least one of"):
+            src.server.update_point(10, session_id=session_id)
+
+    def test_update_point_empty_name_raises(self, session_setup):
+        """Test update_point raises ValueError for empty name."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Point name cannot be empty"):
+            src.server.update_point(10, name="  ", session_id=session_id)
+
+    def test_delete_point(self, session_setup):
+        """Test delete_point deletes a point value."""
+        session_id, mock_client = session_setup
+        mock_client.api.delete.return_value = None
+
+        result = src.server.delete_point(10, session_id)
+
+        mock_client.api.delete.assert_called_once_with("/points/10")
+        assert result["status"] == "deleted"
+        assert result["point_id"] == 10
+
     # ─── Epic tools tests ────────────────────────────────────────────
 
     def test_list_epics(self, session_setup):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -1071,6 +1072,75 @@ class TestTaigaTools:
         assert result["id"] == 400
         assert result["slug"] == "home"
         mock_client.api.wiki.get.assert_called_once_with(400)
+
+    def test_get_wiki_page_by_slug(self, session_setup):
+        """Test get_wiki_page_by_slug."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.get_by_slug.return_value = {
+            "id": 400,
+            "slug": "home",
+            "content": "# Welcome",
+            "project": 123,
+            "version": 1,
+        }
+        result = src.server.get_wiki_page_by_slug(123, "home", session_id)
+        assert result["id"] == 400
+        assert result["slug"] == "home"
+        mock_client.api.wiki.get_by_slug.assert_called_once_with(slug="home", project=123)
+
+    def test_get_wiki_page_by_slug_not_found(self, session_setup):
+        """Test get_wiki_page_by_slug raises ValueError when not found."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.get_by_slug.return_value = {}
+        with pytest.raises(ValueError, match="not found"):
+            src.server.get_wiki_page_by_slug(123, "nonexistent", session_id)
+
+    def test_update_wiki_page(self, session_setup):
+        """Test update_wiki_page."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.get.return_value = {
+            "id": 400,
+            "slug": "home",
+            "content": "# Welcome",
+            "project": 123,
+            "version": 1,
+        }
+        mock_client.api.wiki.edit.return_value = {
+            "id": 400,
+            "slug": "home",
+            "content": "# Updated",
+            "project": 123,
+            "version": 2,
+        }
+        result = src.server.update_wiki_page(400, json.dumps({"content": "# Updated"}), session_id)
+        assert result["content"] == "# Updated"
+        assert result["version"] == 2
+        mock_client.api.wiki.edit.assert_called_once_with(
+            wiki_page_id=400, version=1, data={"content": "# Updated"}
+        )
+
+    def test_update_wiki_page_no_kwargs(self, session_setup):
+        """Test update_wiki_page with no kwargs returns current state."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.get.return_value = {
+            "id": 400,
+            "slug": "home",
+            "content": "# Welcome",
+            "project": 123,
+            "version": 1,
+        }
+        result = src.server.update_wiki_page(400, None, session_id)
+        assert result["id"] == 400
+        mock_client.api.wiki.edit.assert_not_called()
+
+    def test_delete_wiki_page(self, session_setup):
+        """Test delete_wiki_page."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.delete.return_value = None
+        result = src.server.delete_wiki_page(400, session_id)
+        assert result["status"] == "deleted"
+        assert result["wiki_page_id"] == 400
+        mock_client.api.wiki.delete.assert_called_once_with(wiki_page_id=400)
 
     # ─── Verbosity tests for various tools ───────────────────────────
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -211,16 +211,17 @@ class TestTaigaTools:
     def test_list_projects(self, session_setup):
         """Test list_projects functionality"""
         session_id, mock_client = session_setup
-        mock_client.api.projects.list.return_value = [{"id": 123, "name": "Test Project"}]
+        mock_client.list_resources.return_value = [{"id": 123, "name": "Test Project"}]
         projects = src.server.list_projects(session_id)
         assert len(projects) == 1
         assert projects[0]["name"] == "Test Project"
         assert projects[0]["id"] == 123
+        mock_client.list_resources.assert_called_once_with("projects")
 
     def test_list_all_projects(self, session_setup):
         """Test list_all_projects delegates to list_projects."""
         session_id, mock_client = session_setup
-        mock_client.api.projects.list.return_value = [{"id": 1, "name": "P1"}]
+        mock_client.list_resources.return_value = [{"id": 1, "name": "P1"}]
         projects = src.server.list_all_projects(session_id)
         assert len(projects) == 1
 
@@ -333,18 +334,18 @@ class TestTaigaTools:
     def test_list_user_stories(self, session_setup):
         """Test list_user_stories functionality"""
         session_id, mock_client = session_setup
-        mock_client.api.user_stories.list.return_value = [{"id": 456, "subject": "Test User Story"}]
+        mock_client.list_resources.return_value = [{"id": 456, "subject": "Test User Story"}]
         stories = src.server.list_user_stories(123, "{}", session_id)
         assert len(stories) == 1
         assert stories[0]["subject"] == "Test User Story"
-        mock_client.api.user_stories.list.assert_called_once_with(project=123)
+        mock_client.list_resources.assert_called_once_with("user_stories", project_id=123)
 
     def test_list_user_stories_with_filters(self, session_setup):
         """Test list_user_stories with filters."""
         session_id, mock_client = session_setup
-        mock_client.api.user_stories.list.return_value = [{"id": 1, "subject": "Filtered"}]
+        mock_client.list_resources.return_value = [{"id": 1, "subject": "Filtered"}]
         src.server.list_user_stories(123, '{"status": 1}', session_id)
-        mock_client.api.user_stories.list.assert_called_once_with(project=123, status=1)
+        mock_client.list_resources.assert_called_once_with("user_stories", project_id=123, status=1)
 
     def test_create_user_story(self, session_setup):
         """Test create_user_story functionality"""
@@ -473,35 +474,31 @@ class TestTaigaTools:
     def test_get_user_story_statuses(self, session_setup):
         """Test get_user_story_statuses."""
         session_id, mock_client = session_setup
-        mock_client.api.userstory_statuses.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "New"},
             {"id": 2, "name": "In Progress"},
         ]
         result = src.server.get_user_story_statuses(123, session_id)
         assert len(result) == 2
-        mock_client.api.userstory_statuses.list.assert_called_once_with(
-            query_params={"project": 123}
-        )
+        mock_client.list_resources.assert_called_once_with("userstory_statuses", project_id=123)
 
     # ─── Task tools tests ────────────────────────────────────────────
 
     def test_list_tasks(self, session_setup):
         """Test list_tasks functionality"""
         session_id, mock_client = session_setup
-        mock_client.api.get.return_value = [{"id": 789, "subject": "Test Task"}]
+        mock_client.list_resources.return_value = [{"id": 789, "subject": "Test Task"}]
         tasks = src.server.list_tasks(123, "{}", session_id)
         assert len(tasks) == 1
         assert tasks[0]["subject"] == "Test Task"
-        mock_client.api.get.assert_called_once_with("/tasks", params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("tasks", project_id=123)
 
     def test_list_tasks_with_filters(self, session_setup):
         """Test list_tasks with filters."""
         session_id, mock_client = session_setup
-        mock_client.api.get.return_value = [{"id": 1, "subject": "Filtered"}]
+        mock_client.list_resources.return_value = [{"id": 1, "subject": "Filtered"}]
         src.server.list_tasks(123, '{"milestone": 5}', session_id)
-        mock_client.api.get.assert_called_once_with(
-            "/tasks", params={"project": 123, "milestone": 5}
-        )
+        mock_client.list_resources.assert_called_once_with("tasks", project_id=123, milestone=5)
 
     def test_create_task(self, session_setup):
         """Test create_task."""
@@ -625,20 +622,18 @@ class TestTaigaTools:
     def test_list_issues(self, session_setup):
         """Test list_issues."""
         session_id, mock_client = session_setup
-        mock_client.api.issues.list.return_value = [{"id": 100, "subject": "Bug"}]
+        mock_client.list_resources.return_value = [{"id": 100, "subject": "Bug"}]
         result = src.server.list_issues(123, "{}", session_id)
         assert len(result) == 1
         assert result[0]["subject"] == "Bug"
-        mock_client.api.issues.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("issues", project_id=123)
 
     def test_list_issues_with_filters(self, session_setup):
         """Test list_issues with filters."""
         session_id, mock_client = session_setup
-        mock_client.api.issues.list.return_value = []
+        mock_client.list_resources.return_value = []
         src.server.list_issues(123, '{"priority": 3}', session_id)
-        mock_client.api.issues.list.assert_called_once_with(
-            query_params={"project": 123, "priority": 3}
-        )
+        mock_client.list_resources.assert_called_once_with("issues", project_id=123, priority=3)
 
     def test_create_issue(self, session_setup):
         """Test create_issue."""
@@ -764,18 +759,18 @@ class TestTaigaTools:
     def test_get_issue_statuses(self, session_setup):
         """Test get_issue_statuses."""
         session_id, mock_client = session_setup
-        mock_client.api.issue_statuses.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "New"},
             {"id": 2, "name": "Closed"},
         ]
         result = src.server.get_issue_statuses(123, session_id)
         assert len(result) == 2
-        mock_client.api.issue_statuses.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("issue_statuses", project_id=123)
 
     def test_get_issue_priorities(self, session_setup):
-        """Test get_issue_priorities uses direct GET with /priorities endpoint."""
+        """Test get_issue_priorities."""
         session_id, mock_client = session_setup
-        mock_client.api.get.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "Low"},
             {"id": 2, "name": "Normal"},
             {"id": 3, "name": "High"},
@@ -783,13 +778,12 @@ class TestTaigaTools:
         result = src.server.get_issue_priorities(123, session_id)
         assert len(result) == 3
         assert result[0]["name"] == "Low"
-        # Verify it uses the direct GET call, not issue_priorities.list
-        mock_client.api.get.assert_called_once_with("/priorities", params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("priorities", project_id=123)
 
     def test_get_issue_severities(self, session_setup):
-        """Test get_issue_severities uses direct GET with /severities endpoint."""
+        """Test get_issue_severities."""
         session_id, mock_client = session_setup
-        mock_client.api.get.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "Wishlist"},
             {"id": 2, "name": "Minor"},
             {"id": 3, "name": "Normal"},
@@ -797,39 +791,36 @@ class TestTaigaTools:
         result = src.server.get_issue_severities(123, session_id)
         assert len(result) == 3
         assert result[0]["name"] == "Wishlist"
-        # Verify it uses the direct GET call, not issue_severities.list
-        mock_client.api.get.assert_called_once_with("/severities", params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("severities", project_id=123)
 
     def test_get_issue_types(self, session_setup):
         """Test get_issue_types."""
         session_id, mock_client = session_setup
-        mock_client.api.issue_types.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "Bug"},
             {"id": 2, "name": "Enhancement"},
         ]
         result = src.server.get_issue_types(123, session_id)
         assert len(result) == 2
-        mock_client.api.issue_types.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("issue_types", project_id=123)
 
     # ─── Epic tools tests ────────────────────────────────────────────
 
     def test_list_epics(self, session_setup):
         """Test list_epics."""
         session_id, mock_client = session_setup
-        mock_client.api.epics.list.return_value = [{"id": 200, "subject": "Epic 1"}]
+        mock_client.list_resources.return_value = [{"id": 200, "subject": "Epic 1"}]
         result = src.server.list_epics(123, "{}", session_id)
         assert len(result) == 1
         assert result[0]["subject"] == "Epic 1"
-        mock_client.api.epics.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("epics", project_id=123)
 
     def test_list_epics_with_filters(self, session_setup):
         """Test list_epics with filters."""
         session_id, mock_client = session_setup
-        mock_client.api.epics.list.return_value = []
+        mock_client.list_resources.return_value = []
         src.server.list_epics(123, '{"status": 2}', session_id)
-        mock_client.api.epics.list.assert_called_once_with(
-            query_params={"project": 123, "status": 2}
-        )
+        mock_client.list_resources.assert_called_once_with("epics", project_id=123, status=2)
 
     def test_create_epic(self, session_setup):
         """Test create_epic."""
@@ -944,13 +935,13 @@ class TestTaigaTools:
     def test_list_milestones(self, session_setup):
         """Test list_milestones."""
         session_id, mock_client = session_setup
-        mock_client.api.milestones.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 300, "name": "Sprint 1", "slug": "sprint-1", "project": 123}
         ]
         result = src.server.list_milestones(123, session_id)
         assert len(result) == 1
         assert result[0]["name"] == "Sprint 1"
-        mock_client.api.milestones.list.assert_called_once_with(project=123)
+        mock_client.list_resources.assert_called_once_with("milestones", project_id=123)
 
     def test_create_milestone(self, session_setup):
         """Test create_milestone."""
@@ -1027,13 +1018,13 @@ class TestTaigaTools:
     def test_get_project_members(self, session_setup):
         """Test get_project_members."""
         session_id, mock_client = session_setup
-        mock_client.api.memberships.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "user": 10, "full_name": "John Doe", "role_name": "Admin"}
         ]
         result = src.server.get_project_members(123, session_id)
         assert len(result) == 1
         assert result[0]["full_name"] == "John Doe"
-        mock_client.api.memberships.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("memberships", project_id=123)
 
     def test_invite_project_user(self, session_setup):
         """Test invite_project_user."""
@@ -1060,11 +1051,11 @@ class TestTaigaTools:
     def test_list_wiki_pages(self, session_setup):
         """Test list_wiki_pages."""
         session_id, mock_client = session_setup
-        mock_client.api.wiki.list.return_value = [{"id": 400, "slug": "home", "project": 123}]
+        mock_client.list_resources.return_value = [{"id": 400, "slug": "home", "project": 123}]
         result = src.server.list_wiki_pages(123, session_id)
         assert len(result) == 1
         assert result[0]["slug"] == "home"
-        mock_client.api.wiki.list.assert_called_once_with(query_params={"project": 123})
+        mock_client.list_resources.assert_called_once_with("wiki", project_id=123)
 
     def test_get_wiki_page(self, session_setup):
         """Test get_wiki_page."""
@@ -1086,7 +1077,7 @@ class TestTaigaTools:
     def test_list_projects_verbosity_minimal(self, session_setup):
         """Test list_projects with minimal verbosity."""
         session_id, mock_client = session_setup
-        mock_client.api.projects.list.return_value = [
+        mock_client.list_resources.return_value = [
             {"id": 1, "name": "P1", "slug": "p1", "description": "Long desc", "version": 1}
         ]
         result = src.server.list_projects(session_id, verbosity="minimal")
@@ -1440,42 +1431,60 @@ class TestTaigaClientWrapper:
         with pytest.raises(PermissionError):
             wrapper.list_resources("projects")
 
-    def test_list_resources_raw_api(self):
-        """Test list_resources uses raw API for tasks."""
+    def test_list_resources_sends_disable_pagination_header(self):
+        """Test list_resources sends x-disable-pagination header."""
         wrapper = TaigaClientWrapper(host="http://test:9000")
         wrapper.api = MagicMock()
         wrapper.api.auth_token = "test-token"
         wrapper.api.get.return_value = [{"id": 1}]
-        result = wrapper.list_resources("tasks", project_id=123)
-        wrapper.api.get.assert_called_once_with("/tasks", params={"project": 123})
-        assert result == [{"id": 1}]
+        wrapper.list_resources("projects")
+        wrapper.api.get.assert_called_once_with(
+            "/projects", params={}, headers={"x-disable-pagination": "True"}
+        )
 
-    def test_list_resources_project_kwarg(self):
-        """Test list_resources uses project kwarg for user_stories."""
+    def test_list_resources_endpoint_mapping(self):
+        """Test list_resources maps resource types to correct endpoints."""
+        from src.taiga_client import _RESOURCE_ENDPOINTS
+
         wrapper = TaigaClientWrapper(host="http://test:9000")
         wrapper.api = MagicMock()
         wrapper.api.auth_token = "test-token"
-        wrapper.api.user_stories.list.return_value = [{"id": 1}]
-        result = wrapper.list_resources("user_stories", project_id=123)
-        wrapper.api.user_stories.list.assert_called_once_with(project=123)
-        assert result == [{"id": 1}]
+        wrapper.api.get.return_value = []
+        for resource_type, endpoint in _RESOURCE_ENDPOINTS.items():
+            wrapper.api.get.reset_mock()
+            wrapper.list_resources(resource_type)
+            call_args = wrapper.api.get.call_args
+            assert call_args[0][0] == endpoint, f"{resource_type} -> {endpoint}"
 
-    def test_list_resources_query_params(self):
-        """Test list_resources uses query_params for issues."""
+    def test_list_resources_with_filters(self):
+        """Test list_resources passes filters as params."""
         wrapper = TaigaClientWrapper(host="http://test:9000")
         wrapper.api = MagicMock()
         wrapper.api.auth_token = "test-token"
-        wrapper.api.issues.list.return_value = [{"id": 1}]
-        result = wrapper.list_resources("issues", project_id=123)
-        wrapper.api.issues.list.assert_called_once_with(query_params={"project": 123})
+        wrapper.api.get.return_value = [{"id": 1}]
+        result = wrapper.list_resources("issues", project_id=123, status=2)
+        wrapper.api.get.assert_called_once_with(
+            "/issues",
+            params={"project": 123, "status": 2},
+            headers={"x-disable-pagination": "True"},
+        )
         assert result == [{"id": 1}]
+
+    def test_list_resources_no_project_id(self):
+        """Test list_resources omits project key when project_id is None."""
+        wrapper = TaigaClientWrapper(host="http://test:9000")
+        wrapper.api = MagicMock()
+        wrapper.api.auth_token = "test-token"
+        wrapper.api.get.return_value = [{"id": 1}]
+        wrapper.list_resources("projects")
+        call_params = wrapper.api.get.call_args[1]["params"]
+        assert "project" not in call_params
 
     def test_list_resources_unknown_type(self):
         """Test list_resources raises for unknown resource type."""
         wrapper = TaigaClientWrapper(host="http://test:9000")
         wrapper.api = MagicMock()
         wrapper.api.auth_token = "test-token"
-        wrapper.api.nonexistent = None
         with pytest.raises(ValueError, match="Unknown resource type"):
             wrapper.list_resources("nonexistent")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1716,6 +1716,221 @@ class TestTaigaTools:
         with pytest.raises(ValueError, match="No session_id provided"):
             src.server.search_project(21, "query")
 
+    # ─── Bulk Operations tests ────────────────────────────────────────
+
+    def test_bulk_create_user_stories(self, session_setup):
+        """Test bulk_create_user_stories calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = [
+            {"id": 1, "subject": "Story A"},
+            {"id": 2, "subject": "Story B"},
+        ]
+        result = src.server.bulk_create_user_stories(
+            21, ["Story A", "Story B"], session_id=session_id
+        )
+        mock_client.api.post.assert_called_once_with(
+            "/userstories/bulk_create",
+            json={"project_id": 21, "bulk_stories": "Story A\nStory B"},
+        )
+        assert len(result) == 2
+
+    def test_bulk_create_user_stories_empty_raises(self, session_setup):
+        """Test bulk_create_user_stories raises on empty list."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Subjects list cannot be empty"):
+            src.server.bulk_create_user_stories(21, [], session_id=session_id)
+
+    def test_bulk_create_user_stories_whitespace_only_raises(self, session_setup):
+        """Test bulk_create_user_stories raises when all subjects are whitespace."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="only empty strings"):
+            src.server.bulk_create_user_stories(21, ["  ", "", " "], session_id=session_id)
+
+    def test_bulk_create_user_stories_strips_subjects(self, session_setup):
+        """Test bulk_create_user_stories strips whitespace from subjects."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = [{"id": 1, "subject": "Story A"}]
+        src.server.bulk_create_user_stories(21, ["  Story A  "], session_id=session_id)
+        call_json = mock_client.api.post.call_args[1]["json"]
+        assert call_json["bulk_stories"] == "Story A"
+
+    def test_bulk_create_tasks(self, session_setup):
+        """Test bulk_create_tasks calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = [{"id": 1, "subject": "Task A"}]
+        result = src.server.bulk_create_tasks(21, ["Task A"], session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/tasks/bulk_create",
+            json={"project_id": 21, "bulk_tasks": "Task A"},
+        )
+        assert len(result) == 1
+
+    def test_bulk_create_tasks_with_user_story(self, session_setup):
+        """Test bulk_create_tasks includes us_id when user_story_id provided."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = [{"id": 1, "subject": "Task A"}]
+        src.server.bulk_create_tasks(21, ["Task A"], user_story_id=5, session_id=session_id)
+        call_json = mock_client.api.post.call_args[1]["json"]
+        assert call_json["us_id"] == 5
+
+    def test_bulk_create_tasks_empty_raises(self, session_setup):
+        """Test bulk_create_tasks raises on empty list."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Subjects list cannot be empty"):
+            src.server.bulk_create_tasks(21, [], session_id=session_id)
+
+    def test_bulk_create_issues(self, session_setup):
+        """Test bulk_create_issues calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = [{"id": 1, "subject": "Issue A"}]
+        result = src.server.bulk_create_issues(21, ["Issue A"], session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/issues/bulk_create",
+            json={"project_id": 21, "bulk_issues": "Issue A"},
+        )
+        assert len(result) == 1
+
+    def test_bulk_create_issues_empty_raises(self, session_setup):
+        """Test bulk_create_issues raises on empty list."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Subjects list cannot be empty"):
+            src.server.bulk_create_issues(21, [], session_id=session_id)
+
+    def test_bulk_create_epics(self, session_setup):
+        """Test bulk_create_epics calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = [{"id": 1, "subject": "Epic A"}]
+        result = src.server.bulk_create_epics(21, ["Epic A"], session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/epics/bulk_create",
+            json={"project_id": 21, "bulk_epics": "Epic A"},
+        )
+        assert len(result) == 1
+
+    def test_bulk_create_epics_empty_raises(self, session_setup):
+        """Test bulk_create_epics raises on empty list."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Subjects list cannot be empty"):
+            src.server.bulk_create_epics(21, [], session_id=session_id)
+
+    def test_bulk_update_user_story_milestone(self, session_setup):
+        """Test bulk_update_user_story_milestone calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+        stories = [{"us_id": 1, "order": 1}, {"us_id": 2, "order": 2}]
+        result = src.server.bulk_update_user_story_milestone(21, 5, stories, session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/userstories/bulk_update_milestone",
+            json={"project_id": 21, "milestone_id": 5, "bulk_stories": stories},
+        )
+        assert result["status"] == "updated"
+        assert result["stories_moved"] == 2
+
+    def test_bulk_update_user_story_milestone_empty_raises(self, session_setup):
+        """Test bulk_update_user_story_milestone raises on empty list."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="bulk_stories list cannot be empty"):
+            src.server.bulk_update_user_story_milestone(21, 5, [], session_id=session_id)
+
+    def test_bulk_update_user_story_order_backlog(self, session_setup):
+        """Test bulk_update_user_story_order with backlog order type."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+        stories = [{"us_id": 1, "order": 10}]
+        result = src.server.bulk_update_user_story_order(
+            21, "backlog", stories, session_id=session_id
+        )
+        mock_client.api.post.assert_called_once_with(
+            "/userstories/bulk_update_backlog_order",
+            json={"project_id": 21, "bulk_stories": stories},
+        )
+        assert result["status"] == "reordered"
+        assert result["order_type"] == "backlog"
+
+    def test_bulk_update_user_story_order_kanban(self, session_setup):
+        """Test bulk_update_user_story_order with kanban order type."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+        stories = [{"us_id": 1, "order": 10}]
+        src.server.bulk_update_user_story_order(21, "kanban", stories, session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/userstories/bulk_update_kanban_order",
+            json={"project_id": 21, "bulk_stories": stories},
+        )
+
+    def test_bulk_update_user_story_order_sprint(self, session_setup):
+        """Test bulk_update_user_story_order with sprint order type."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+        stories = [{"us_id": 1, "order": 10}]
+        src.server.bulk_update_user_story_order(21, "sprint", stories, session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/userstories/bulk_update_sprint_order",
+            json={"project_id": 21, "bulk_stories": stories},
+        )
+
+    def test_bulk_update_user_story_order_invalid_type_raises(self, session_setup):
+        """Test bulk_update_user_story_order raises on invalid order type."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Invalid order_type"):
+            src.server.bulk_update_user_story_order(
+                21, "invalid", [{"us_id": 1, "order": 1}], session_id=session_id
+            )
+
+    def test_bulk_update_user_story_order_empty_raises(self, session_setup):
+        """Test bulk_update_user_story_order raises on empty list."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="bulk_stories list cannot be empty"):
+            src.server.bulk_update_user_story_order(21, "backlog", [], session_id=session_id)
+
+    def test_bulk_create_memberships(self, session_setup):
+        """Test bulk_create_memberships calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = [{"id": 1, "email": "a@b.com"}]
+        members = [{"email": "a@b.com", "role_id": 3}]
+        result = src.server.bulk_create_memberships(21, members, session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/memberships/bulk_create",
+            json={"project_id": 21, "bulk_memberships": members},
+        )
+        assert result["status"] == "invited"
+
+    def test_bulk_create_memberships_empty_raises(self, session_setup):
+        """Test bulk_create_memberships raises on empty list."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Members list cannot be empty"):
+            src.server.bulk_create_memberships(21, [], session_id=session_id)
+
+    def test_bulk_create_memberships_missing_fields_raises(self, session_setup):
+        """Test bulk_create_memberships raises when member dict missing required fields."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="must have 'email' and 'role_id'"):
+            src.server.bulk_create_memberships(21, [{"email": "a@b.com"}], session_id=session_id)
+
+    def test_bulk_link_user_stories_to_epic(self, session_setup):
+        """Test bulk_link_user_stories_to_epic calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+        result = src.server.bulk_link_user_stories_to_epic(10, [1, 2, 3], session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/epics/10/related_userstories/bulk_create",
+            json={"project_id": 10, "bulk_userstories": [1, 2, 3]},
+        )
+        assert result["status"] == "linked"
+        assert result["count"] == 3
+
+    def test_bulk_link_user_stories_to_epic_empty_raises(self, session_setup):
+        """Test bulk_link_user_stories_to_epic raises on empty list."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="user_story_ids list cannot be empty"):
+            src.server.bulk_link_user_stories_to_epic(10, [], session_id=session_id)
+
+    def test_bulk_create_user_stories_no_session_raises(self):
+        """Test bulk_create_user_stories raises when no session available."""
+        src.server.active_sessions.clear()
+        with pytest.raises(ValueError, match="No session_id provided"):
+            src.server.bulk_create_user_stories(21, ["Story A"])
+
 
 # ─── Response Filtering tests ─────────────────────────────────────────
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1489,6 +1489,64 @@ class TestTaigaTools:
         with pytest.raises(ValueError, match="Comment ID must not be empty"):
             src.server.get_comment_versions(42, "issue", "", session_id)
 
+    # ─── History / Audit Trail tests ───────────────────────────────────
+
+    def test_get_history(self, session_setup):
+        """Test get_history returns full change history."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = [
+            {"id": "a", "type": 1, "values_diff": {"status": ["New", "In progress"]}},
+            {"id": "b", "type": 1, "comment": "Some comment"},
+        ]
+
+        result = src.server.get_history(42, "issue", session_id)
+
+        mock_client.api.get.assert_called_once_with("/history/issue/42")
+        assert result["object_type"] == "issue"
+        assert result["object_id"] == 42
+        assert len(result["history"]) == 2
+
+    def test_get_history_wiki(self, session_setup):
+        """Test get_history works with wiki type."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = []
+
+        result = src.server.get_history(10, "wiki", session_id)
+
+        mock_client.api.get.assert_called_once_with("/history/wiki/10")
+        assert result["history"] == []
+
+    def test_get_history_wiki_page_alias(self, session_setup):
+        """Test get_history maps wiki_page to wiki path."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = []
+
+        src.server.get_history(10, "wiki_page", session_id)
+
+        mock_client.api.get.assert_called_once_with("/history/wiki/10")
+
+    def test_get_history_user_story(self, session_setup):
+        """Test get_history maps user_story to userstory path."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = [{"id": "x"}]
+
+        result = src.server.get_history(5, "user_story", session_id)
+
+        mock_client.api.get.assert_called_once_with("/history/userstory/5")
+        assert len(result["history"]) == 1
+
+    def test_get_history_invalid_type_raises(self, session_setup):
+        """Test get_history raises ValueError for invalid object_type."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Invalid object_type"):
+            src.server.get_history(42, "project", session_id)
+
+    def test_get_history_no_session_raises(self):
+        """Test get_history raises ValueError when no session available."""
+        src.server.active_sessions.clear()
+        with pytest.raises(ValueError, match="No session_id provided"):
+            src.server.get_history(42, "issue")
+
     # ─── Login default session tests (PR: fix/login-default-session-and-slug) ──
 
     def test_login_sets_default_session_when_none_exists(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1313,6 +1313,68 @@ class TestTaigaTools:
             assert src.server.active_sessions[src.server.DEFAULT_SESSION_ID] is existing_default
             src.server.active_sessions.clear()
 
+    # ─── Search tests ──────────────────────────────────────────────────
+
+    def test_search_project(self, session_setup):
+        """Test search_project returns structured results from Taiga search API."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = {
+            "count": 3,
+            "userstories": [{"id": 1, "ref": 10, "subject": "US match"}],
+            "tasks": [{"id": 2, "ref": 20, "subject": "Task match"}],
+            "issues": [{"id": 3, "ref": 30, "subject": "Issue match"}],
+            "wikipages": [],
+            "epics": [],
+        }
+
+        result = src.server.search_project(21, "match", session_id)
+
+        mock_client.api.get.assert_called_once_with(
+            "/search", params={"project": 21, "text": "match"}
+        )
+        assert result["count"] == 3
+        assert len(result["userstories"]) == 1
+        assert len(result["tasks"]) == 1
+        assert len(result["issues"]) == 1
+        assert result["wikipages"] == []
+        assert result["epics"] == []
+
+    def test_search_project_empty_text_raises(self, session_setup):
+        """Test search_project raises ValueError for empty search text."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Search text cannot be empty"):
+            src.server.search_project(21, "", session_id)
+
+    def test_search_project_whitespace_text_raises(self, session_setup):
+        """Test search_project raises ValueError for whitespace-only search text."""
+        session_id, _ = session_setup
+        with pytest.raises(ValueError, match="Search text cannot be empty"):
+            src.server.search_project(21, "   ", session_id)
+
+    def test_search_project_strips_text(self, session_setup):
+        """Test search_project strips whitespace from search text."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = {
+            "count": 0,
+            "userstories": [],
+            "tasks": [],
+            "issues": [],
+            "wikipages": [],
+            "epics": [],
+        }
+
+        src.server.search_project(21, "  hello  ", session_id)
+
+        mock_client.api.get.assert_called_once_with(
+            "/search", params={"project": 21, "text": "hello"}
+        )
+
+    def test_search_project_no_session_raises(self):
+        """Test search_project raises ValueError when no session available."""
+        src.server.active_sessions.clear()
+        with pytest.raises(ValueError, match="No session_id provided"):
+            src.server.search_project(21, "query")
+
 
 # ─── Response Filtering tests ─────────────────────────────────────────
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,50 @@
+"""Tests for transport resolution logic."""
+
+from src.server import _resolve_transport
+
+
+class TestResolveTransport:
+    """Tests for _resolve_transport()."""
+
+    def test_default_is_stdio(self):
+        assert _resolve_transport(argv=[], env={}) == "stdio"
+
+    def test_cli_sse_flag(self):
+        assert _resolve_transport(argv=["server.py", "--sse"], env={}) == "sse"
+
+    def test_cli_streamable_http_flag(self):
+        assert (
+            _resolve_transport(argv=["server.py", "--streamable-http"], env={}) == "streamable-http"
+        )
+
+    def test_env_var_sse(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "sse"}) == "sse"
+
+    def test_env_var_streamable_http(self):
+        assert (
+            _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "streamable-http"})
+            == "streamable-http"
+        )
+
+    def test_env_var_stdio_explicit(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "stdio"}) == "stdio"
+
+    def test_env_var_case_insensitive(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "SSE"}) == "sse"
+
+    def test_cli_takes_precedence_over_env(self):
+        assert (
+            _resolve_transport(
+                argv=["server.py", "--sse"], env={"TAIGA_TRANSPORT": "streamable-http"}
+            )
+            == "sse"
+        )
+
+    def test_unknown_env_var_falls_back_to_stdio(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": "websocket"}) == "stdio"
+
+    def test_empty_env_var_falls_back_to_stdio(self):
+        assert _resolve_transport(argv=[], env={"TAIGA_TRANSPORT": ""}) == "stdio"
+
+    def test_no_env_var_falls_back_to_stdio(self):
+        assert _resolve_transport(argv=[], env={"OTHER_VAR": "value"}) == "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.1.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.3.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- Add 8 bulk operation tools covering batch create, reorder, and link endpoints from the Taiga REST API
- `bulk_create_user_stories`, `bulk_create_tasks`, `bulk_create_issues`, `bulk_create_epics`: create multiple entities from subject lists in a single API call
- `bulk_update_user_story_milestone`: move multiple stories to a sprint at once
- `bulk_update_user_story_order`: reorder stories in backlog/kanban/sprint views
- `bulk_create_memberships`: invite multiple users to a project at once
- `bulk_link_user_stories_to_epic`: link multiple user stories to an epic in one call

## Test plan
- [x] 24 unit tests covering all 8 tools (happy paths, input validation, edge cases)
- [x] ruff lint + format passing
- [x] Full test suite: 212 tests passing (188 existing + 24 new)

Closes #9