### PR TITLE
fix: use PEP 508 direct URL for pytaigaclient so pip can install it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "python-dotenv>=0.15.0",
     "pydantic>=2.4.0",
     "pydantic-settings>=2.0.0",
-    "pytaigaclient",
+    "pytaigaclient @ git+https://github.com/talhaorak/pyTaigaClient.git",
 ]
 
 [project.optional-dependencies]
@@ -79,9 +79,6 @@ token = { env = "GH_TOKEN" }
 
 [tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"
-
-[tool.uv.sources]
-pytaigaclient = { git = "https://github.com/talhaorak/pyTaigaClient.git" }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

Closes #17

`pytaigaclient` is not on PyPI and its source was only declared in `[tool.uv.sources]`, a uv-specific block that `pip` silently ignores. This causes `pip install -e .` to fail immediately:

```
ERROR: No matching distribution found for pytaigaclient
```

## Change

Replace the bare `pytaigaclient` dependency with the [PEP 508 direct URL](https://peps.python.org/pep-0508/#extras) form:

```toml
# before
"pytaigaclient",
# + [tool.uv.sources] block

# after
"pytaigaclient @ git+https://github.com/talhaorak/pyTaigaClient.git",
```

This single-line form is understood by both `pip` and `uv`, so the `[tool.uv.sources]` entry for `pytaigaclient` is no longer needed and has been removed.

## Test plan

- [ ] `python -m venv .venv && source .venv/bin/activate && pip install -e .` completes without errors
- [ ] `uv sync` still works as before